### PR TITLE
fix: Delete Web Notification abou site update in background - MEED-7347 - Meeds-io/meeds#2325

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/listener/WebNotificationSentListener.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/listener/WebNotificationSentListener.java
@@ -18,9 +18,6 @@
  */
 package io.meeds.pwa.listener;
 
-import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_DELETED_EVENT;
-import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_READ_ALL_EVENT;
-import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_READ_EVENT;
 import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_SAVED_EVENT;
 
 import java.util.stream.Stream;
@@ -43,12 +40,7 @@ public class WebNotificationSentListener implements ListenerBase<Object, Object>
 
   private static final Log       LOG         = ExoLogger.getLogger(WebNotificationSentListener.class);
 
-  private static final String[]  EVENT_NAMES = new String[] {
-                                                              NOTIFICATION_WEB_SAVED_EVENT,
-                                                              NOTIFICATION_WEB_DELETED_EVENT,
-                                                              NOTIFICATION_WEB_READ_EVENT,
-                                                              NOTIFICATION_WEB_READ_ALL_EVENT
-  };
+  private static final String[]  EVENT_NAMES = new String[] { NOTIFICATION_WEB_SAVED_EVENT };
 
   @Autowired
   private PwaNotificationService pwaNotificationService;
@@ -68,33 +60,12 @@ public class WebNotificationSentListener implements ListenerBase<Object, Object>
       return;
     }
     try {
-      switch (event.getEventName()) {
-      case NOTIFICATION_WEB_SAVED_EVENT: {
-        Boolean isNew = (Boolean) event.getData();
-        String notificationId = (String) event.getSource();
-        if (isNew != null
-            && isNew.booleanValue()
-            && notificationId != null) {
-          pwaNotificationService.create(Long.parseLong(notificationId));
-        }
-        break;
-      }
-      case NOTIFICATION_WEB_DELETED_EVENT, NOTIFICATION_WEB_READ_EVENT: {
-        String notificationId = (String) event.getSource();
-        if (notificationId != null) {
-          pwaNotificationService.delete(Long.parseLong(notificationId));
-        }
-        break;
-      }
-      case NOTIFICATION_WEB_READ_ALL_EVENT: {
-        String username = (String) event.getSource();
-        if (username != null) {
-          pwaNotificationService.deleteAll(username);
-        }
-        break;
-      }
-      default:
-        throw new IllegalArgumentException("Event not handled: " + event.getEventName());
+      Boolean isNew = (Boolean) event.getData();
+      String notificationId = (String) event.getSource();
+      if (isNew != null
+          && isNew.booleanValue()
+          && notificationId != null) {
+        pwaNotificationService.create(Long.parseLong(notificationId));
       }
     } catch (Exception e) {
       LOG.warn("Error while handling notification event '{}' with id '{}'", event.getEventName(), event.getSource(), e);

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -69,15 +69,7 @@ public class PwaNotificationService {
 
   public static final String           PWA_NOTIFICATION_CREATED                = "pwa.notification.created";
 
-  public static final String           PWA_NOTIFICATION_DELETED                = "pwa.notification.deleted";
-
-  public static final String           PWA_NOTIFICATION_ALL_DELETED            = "pwa.notification.allDeleted";
-
   public static final String           PWA_NOTIFICATION_OPEN_UI_ACTION         = "open";
-
-  public static final String           PWA_NOTIFICATION_CLOSE_UI_ACTION        = "close";
-
-  public static final String           PWA_NOTIFICATION_CLOSE_ALL_UI_ACTION    = "closeAll";
 
   public static final String           PWA_NOTIFICATION_MARK_READ_USER_ACTION  = "markRead";
 
@@ -226,55 +218,10 @@ public class PwaNotificationService {
   }
 
   /**
-   * Delete a previously displayed Push Notification to End user due if not
-   * dismissed yet
-   * 
-   * @param webNotificationId
-   * @return
-   */
-  public ScheduledFuture<?> delete(long webNotificationId) { // NOSONAR
-    if (pwaManifestService.isPwaEnabled()) {
-      return executorService.schedule(() -> this.sendCloseNotification(webNotificationId), 1, TimeUnit.SECONDS);
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * Delete all previously displayed push notifications to user's device(s)
-   * 
-   * @param username
-   */
-  public ScheduledFuture<?> deleteAll(String username) { // NOSONAR
-    if (pwaManifestService.isPwaEnabled()) {
-      return executorService.schedule(() -> this.sendCloseAllNotifications(username), 1, TimeUnit.SECONDS);
-    } else {
-      return null;
-    }
-  }
-
-  /**
    * @return VAPID Public Key encoded using Base64url
    */
   public String getVapidPublicKeyString() {
     return pwaNotificationStorage.getVapidPublicKeyString();
-  }
-
-  private int sendCloseAllNotifications(String username) {
-    int sentCount = sendNotification(RANDOM.nextLong(), PWA_NOTIFICATION_CLOSE_ALL_UI_ACTION, username);
-    if (sentCount > 0) {
-      listenerService.broadcast(PWA_NOTIFICATION_ALL_DELETED, username, null);
-    }
-    return sentCount;
-  }
-
-  private int sendCloseNotification(Long webNotificationId) {
-    NotificationInfo notification = webNotificationService.getNotificationInfo(String.valueOf(webNotificationId));
-    int sentCount = sendNotification(notification, PWA_NOTIFICATION_CLOSE_UI_ACTION);
-    if (sentCount > 0) {
-      listenerService.broadcast(PWA_NOTIFICATION_DELETED, webNotificationId, null);
-    }
-    return sentCount;
   }
 
   private int sendCreateNotification(Long webNotificationId) {

--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -1,67 +1,62 @@
 self.addEventListener('install', event => self.skipWaiting());
 
-self.addEventListener('push', async (event) => {
+self.addEventListener('push', (event) => {
   if (self?.Notification?.permission === 'granted') {
     const data = event?.data?.text?.() || {};
     const action = data.split(':')[1]
-    if (action === 'closeAll') {
-      const notifications = await self.registration.getNotifications();
-      if (notifications?.length) {
-        notifications.forEach(notification => notification.close());
+    event.waitUntil(new Promise(async (resolve, reject) => {
+      try {
+        if (action === 'open') {
+          const notificationId = data.split(':')[0]
+          const webNotification = await fetch(`/pwa/rest/notifications/${notificationId}`, {
+            method: 'GET',
+            credentials: 'include',
+          }).then(resp => resp.ok && resp.json());
+          if (webNotification) {
+            const title = webNotification.title || '';
+            delete webNotification.title;
+            webNotification.icon = webNotification.icon || webNotification.image || self.location.origin + '/pwa/rest/manifest/smallIcon?sizes=72x72';
+            webNotification.data = {
+              notificationId,
+              url: self.location.origin + (webNotification.url || '/'),
+            };
+            delete webNotification.url;
+            if (!webNotification.tag) {
+              delete webNotification.tag;
+              delete webNotification.renotify;
+            }
+            if (!webNotification.image) {
+              delete webNotification.image;
+            }
+            if (!webNotification.lang) {
+              delete webNotification.lang;
+            }
+            if (!webNotification.dir) {
+              delete webNotification.dir;
+            }
+            if (!webNotification.body) {
+              delete webNotification.body;
+            }
+            if (!webNotification.vibrate) {
+              delete webNotification.vibrate;
+            }
+            if (!webNotification.badge) {
+              delete webNotification.badge;
+            }
+            if (!Notification.maxActions || !webNotification.actions) {
+              delete webNotification.actions;
+            } else if (webNotification.actions.length > Notification.maxActions) {
+              webNotification.actions = webNotification.actions.slice(0, Notification.maxActions);
+            }
+            await self.registration.showNotification(title, webNotification);
+            await refreshBadge();
+          }
+        }
+        resolve();
+      } catch (e) {
+        reject(e);
       }
-    } else if (action === 'close') {
-      const notificationId = data.split(':')[0]
-      const notifications = await self.registration.getNotifications();
-      if (notifications?.length) {
-        const notification = notifications.find(notification => notification?.data?.notificationId === notificationId);
-        notification?.close?.();
-      }
-    } else if (action === 'open') {
-      const notificationId = data.split(':')[0]
-      const webNotification = await fetch(`/pwa/rest/notifications/${notificationId}`, {
-        method: 'GET',
-        credentials: 'include',
-      }).then(resp => resp.ok && resp.json());
-      if (webNotification) {
-        const title = webNotification.title || '';
-        delete webNotification.title;
-        webNotification.icon = webNotification.icon || self.location.origin + '/pwa/rest/manifest/smallIcon?sizes=72x72';
-        webNotification.data = {
-          notificationId,
-          url: self.location.origin + (webNotification.url || '/'),
-        };
-        delete webNotification.url;
-        if (!webNotification.tag) {
-          delete webNotification.tag;
-          delete webNotification.renotify;
-        }
-        if (!webNotification.image) {
-          delete webNotification.image;
-        }
-        if (!webNotification.lang) {
-          delete webNotification.lang;
-        }
-        if (!webNotification.dir) {
-          delete webNotification.dir;
-        }
-        if (!webNotification.body) {
-          delete webNotification.body;
-        }
-        if (!webNotification.vibrate) {
-          delete webNotification.vibrate;
-        }
-        if (!webNotification.badge) {
-          webNotification.badge = webNotification.icon;
-        }
-        if (!Notification.maxActions || !webNotification.actions) {
-          delete webNotification.actions;
-        } else if (webNotification.actions.length > Notification.maxActions) {
-          webNotification.actions = webNotification.actions.slice(0, Notification.maxActions);
-        }
-        await self.registration.showNotification(title, webNotification);
-        await refreshBadge();
-      }
-    }
+    }));
   }
 });
 

--- a/pwa-service/src/test/java/io/meeds/pwa/listener/WebNotificationSentListenerTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/listener/WebNotificationSentListenerTest.java
@@ -48,8 +48,6 @@ import io.meeds.pwa.service.PwaNotificationService;
 @ExtendWith(MockitoExtension.class)
 public class WebNotificationSentListenerTest {
 
-  private static final String         TEST_USER       = "testUser";
-
   private static final String         NOTIFICATION_ID = "5";
 
   @MockBean
@@ -67,11 +65,8 @@ public class WebNotificationSentListenerTest {
   @Test
   public void init() {
     webNotificationSentListener.init();
-    verify(listenerService, times(4)).addListener(anyString(), eq(webNotificationSentListener));
+    verify(listenerService, times(1)).addListener(anyString(), eq(webNotificationSentListener));
     verify(listenerService).addListener(NOTIFICATION_WEB_SAVED_EVENT, webNotificationSentListener);
-    verify(listenerService).addListener(NOTIFICATION_WEB_DELETED_EVENT, webNotificationSentListener);
-    verify(listenerService).addListener(NOTIFICATION_WEB_READ_EVENT, webNotificationSentListener);
-    verify(listenerService).addListener(NOTIFICATION_WEB_READ_ALL_EVENT, webNotificationSentListener);
   }
 
   @Test
@@ -95,39 +90,6 @@ public class WebNotificationSentListenerTest {
     when(event.getSource()).thenReturn(NOTIFICATION_ID);
     webNotificationSentListener.onEvent(event);
     verify(pwaNotificationService).create(Long.parseLong(NOTIFICATION_ID));
-  }
-
-  @Test
-  public void onEventWhenWebNotifDeleted() throws Exception {
-    when(event.getEventName()).thenReturn(NOTIFICATION_WEB_DELETED_EVENT);
-    webNotificationSentListener.onEvent(event);
-    verifyNoMoreInteractions(pwaNotificationService);
-
-    when(event.getSource()).thenReturn(NOTIFICATION_ID);
-    webNotificationSentListener.onEvent(event);
-    verify(pwaNotificationService).delete(Long.parseLong(NOTIFICATION_ID));
-  }
-
-  @Test
-  public void onEventWhenWebNotifRead() throws Exception {
-    when(event.getEventName()).thenReturn(NOTIFICATION_WEB_READ_EVENT);
-    webNotificationSentListener.onEvent(event);
-    verifyNoMoreInteractions(pwaNotificationService);
-
-    when(event.getSource()).thenReturn(NOTIFICATION_ID);
-    webNotificationSentListener.onEvent(event);
-    verify(pwaNotificationService).delete(Long.parseLong(NOTIFICATION_ID));
-  }
-
-  @Test
-  public void onEventWhenWebNotifAllRead() throws Exception {
-    when(event.getEventName()).thenReturn(NOTIFICATION_WEB_READ_ALL_EVENT);
-    webNotificationSentListener.onEvent(event);
-    verifyNoMoreInteractions(pwaNotificationService);
-
-    when(event.getSource()).thenReturn(TEST_USER);
-    webNotificationSentListener.onEvent(event);
-    verify(pwaNotificationService).deleteAll(TEST_USER);
   }
 
 }

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
@@ -18,8 +18,6 @@
  */
 package io.meeds.pwa.service;
 
-import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_CLOSE_ALL_UI_ACTION;
-import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_CLOSE_UI_ACTION;
 import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_MARK_READ_USER_ACTION;
 import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_OPEN_UI_ACTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -213,81 +211,6 @@ public class PwaNotificationServiceTest {
 
     when(statusLine.getStatusCode()).thenReturn(200);
     future = pwaNotificationService.create(NOTIFICATION_ID);
-    assertNotNull(future);
-    assertEquals(1, (int) future.get());
-    verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-  }
-
-  @Test
-  public void delete() throws Exception { // NOSONAR
-    ScheduledFuture<?> future = pwaNotificationService.delete(NOTIFICATION_ID);
-    assertNull(future);
-    when(pwaManifestService.isPwaEnabled()).thenReturn(true);
-    future = pwaNotificationService.delete(NOTIFICATION_ID);
-    assertNotNull(future);
-    assertEquals(0, (int) future.get());
-    verifyNoInteractions(listenerService);
-
-    mockWebNotification();
-    when(pwaSubscriptionService.getSubscriptions(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
-    when(userPushSubscription.getEndpoint()).thenReturn(SUBSCRIPTION_ENDPOINT);
-    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
-    when(pushService.send(any())).thenReturn(httpResponse);
-    when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    when(statusLine.getStatusCode()).thenReturn(401);
-
-    future = pwaNotificationService.delete(NOTIFICATION_ID);
-    assertNotNull(future);
-    assertEquals(0, (int) future.get());
-    verify(pwaSubscriptionService, never()).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-    verify(pushService).send(argThat(n -> (NOTIFICATION_ID + ":" +
-        PWA_NOTIFICATION_CLOSE_UI_ACTION).equals(new String(n.getPayload()))));
-
-    when(statusLine.getStatusCode()).thenReturn(410);
-    future = pwaNotificationService.delete(NOTIFICATION_ID);
-    assertNotNull(future);
-    assertEquals(0, (int) future.get());
-    verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-
-    when(statusLine.getStatusCode()).thenReturn(200);
-    future = pwaNotificationService.delete(NOTIFICATION_ID);
-    assertNotNull(future);
-    assertEquals(1, (int) future.get());
-    verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-  }
-
-  @Test
-  public void deleteAll() throws Exception { // NOSONAR
-    ScheduledFuture<?> future = pwaNotificationService.deleteAll(TEST_USER);
-    assertNull(future);
-    when(pwaManifestService.isPwaEnabled()).thenReturn(true);
-    future = pwaNotificationService.deleteAll(TEST_USER);
-    assertNotNull(future);
-    assertEquals(0, (int) future.get());
-    verifyNoInteractions(listenerService);
-
-    mockWebNotification();
-    when(pwaSubscriptionService.getSubscriptions(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
-    when(userPushSubscription.getEndpoint()).thenReturn(SUBSCRIPTION_ENDPOINT);
-    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
-    when(pushService.send(any())).thenReturn(httpResponse);
-    when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    when(statusLine.getStatusCode()).thenReturn(401);
-
-    future = pwaNotificationService.deleteAll(TEST_USER);
-    assertNotNull(future);
-    assertEquals(0, (int) future.get());
-    verify(pwaSubscriptionService, never()).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-    verify(pushService).send(argThat(n -> new String(n.getPayload()).contains(":" + PWA_NOTIFICATION_CLOSE_ALL_UI_ACTION)));
-
-    when(statusLine.getStatusCode()).thenReturn(410);
-    future = pwaNotificationService.deleteAll(TEST_USER);
-    assertNotNull(future);
-    assertEquals(0, (int) future.get());
-    verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-
-    when(statusLine.getStatusCode()).thenReturn(200);
-    future = pwaNotificationService.deleteAll(TEST_USER);
     assertNotNull(future);
     assertEquals(1, (int) future.get());
     verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);


### PR DESCRIPTION
Prior to this change, some 'Silent Push' notification messages were sent to end user devices when the Web Notification is marked as read from the Notification Center, which leads to display a 'system' web notification with message 'This site has been updated in the background'. This message is a system message which is displayed when a push message is sent to end user without a visible Device Notification. Thus this change will delete the automatic Device Notification closing from all devices when a notification is marked as read from Web Notification Center.