### PR TITLE
fix: Avoid Displaying Notification API Choice Snackbar when Already Denied - MEED-8396 - Meeds-io/meeds#2631

### DIFF
--- a/pwa-webapp/src/main/webapp/js/pwa.js
+++ b/pwa-webapp/src/main/webapp/js/pwa.js
@@ -100,19 +100,13 @@
         }
       });
 
-      if (!('PushManager' in window)) {
+      if (!('PushManager' in window) || !('Notification' in window)) {
         return;
-      }
-
-      if (!('Notification' in window)) {
-        return;
-      } else if (Notification.permission === 'denied'
-        && window.localStorage.getItem(`pwa.notification.suggested-${eXo.env.portal.userName}`)) {
-        return;
-      }
-
-      if (Notification.permission === 'granted') {
+      } else if (Notification.permission === 'granted') {
         subscribe(registration);
+      } else if (Notification.permission === 'denied'
+        || window.localStorage.getItem(`pwa.notification.suggested-${eXo.env.portal.userName}`)) {
+        return;
       } else {
         const i18n = await exoi18n.loadLanguageAsync(eXo.env.portal.language, `/social/i18n/locale.portlet.Portlets?lang=${eXo.env.portal.language}`);
         window.setTimeout(() => {


### PR DESCRIPTION
Prior to this change, When using **Safe Browsing** option for App, and after having denied the Notifications to be displayed in the device, then the `Snackbar` is displayed again when re-opening the app. This change will ensure to not propose to enable Notification API when the Notifications API is already refused even when the user didn't get the `snackbar` displayed before.

Resolves https://github.com/Meeds-io/meeds/issues/2631