### PR TITLE
fix: Avoid changing Manifest Location - MEED-8638 - Meeds-io/MIPs#185

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
@@ -76,7 +76,7 @@ public class PwaManifestRest {
       return ResponseEntity.ok()
                            .eTag(String.valueOf(eTag))
                            .lastModified(Instant.now())
-                           .cacheControl(CacheControl.maxAge(Duration.ofDays(365)))
+                           .cacheControl(CacheControl.maxAge(Duration.ofMinutes(1)))
                            .body(pwaManifestService.getManifestContent(request.getRemoteUser()));
     }
   }

--- a/pwa-webapp/src/main/webapp/groovy/portal/webui/workspace/UIPortalPWAHeadStart.gtmpl
+++ b/pwa-webapp/src/main/webapp/groovy/portal/webui/workspace/UIPortalPWAHeadStart.gtmpl
@@ -10,6 +10,6 @@
 %><meta name="theme-color" content="<%=pwaManifestService.getThemeColor()%>"/>
 <%
   if (pwaManifestService.isPwaEnabled()) {
-%><link rel="manifest" href="<%="/pwa/rest/manifest?v=" + pwaManifestService.getManifestHash(PortalRequestContext.getCurrentInstance().getRemoteUser())%>" crossorigin="use-credentials"><%
+%><link rel="manifest" href="<%="/pwa/rest/manifest"%>" crossorigin="use-credentials"><%
   }
 %>


### PR DESCRIPTION
Prior to this change, the Manifest location changes when an admin changes its properties. This change ensures to use the same location all time to ensure compatibility with all browsers.