### PR TITLE
fix: Automatic redirection on oidc is not working with PWA - MEED-9446

### DIFF
--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -77,11 +77,15 @@ const activateNavigationPreload = async () => {
   }
 };
 
-const requestWithFallback = async ({ request }) => {
+const requestWithFallback = async (event) => {
   let response;
+  const request = event.request;
   const assetUrl = offlineAssets.find(url => request.url?.includes?.(url));
   try {
-    response = await fetch(request);
+    response = await event.preloadResponse;
+    if (!response) {
+      response = await fetch(request);
+    }
     if (response.status >= 400) {
       throw new Error();
     } else if (response.headers.get('Content-Type') === 'text/html') {


### PR DESCRIPTION
Before this fix, when user is on public site and click on login button, the login request is launched twice : on by preload due to NavigationPreloadManager, and once by the service worker This fix improves the service worker by reusing the result of the preload if exists, instead of refetch the query.

The fact that OIDC is not working is due to the login request, in certain context start the OIDC login flow and initiate a state. Then, launching the request twice make the state incoherent.

Resolves Meeds-io/meeds#3491

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
