### PR TITLE
feat: allow sending notification other than web notification - MEED-9270 - Meeds-io/MIPs#189

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -1,8 +1,8 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * 
+ *
  * Copyright (C) 2022 Meeds Association contact@meeds.io
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -11,7 +11,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -28,9 +28,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.ecs.storage.Hash;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,6 +94,8 @@ public class PwaNotificationService {
   public static final String           EVENT_NOTIFICATION_ID_PARAM_NAME        = "notificationId";
 
   public static final String           EVENT_ACTION_PARAM_NAME                 = "action";
+
+  public static final String           EVENT_USERNAME_PARAM_NAME               = "username";
 
   public static final String           EVENT_DURATION_PARAM_NAME               = "duration";
 
@@ -180,7 +184,7 @@ public class PwaNotificationService {
                                                       .orElse(defaultPwaNotificationPlugin);
     LocaleConfig localeConfig = getLocaleConfig(username);
     PwaNotificationMessage notificationMessage = notificationPlugin.process(notification, localeConfig);
-    setDefaultNotificationMessageProperties(notificationMessage, notification, localeConfig);
+    setDefaultNotificationMessageProperties(notificationMessage, notification.getId(), localeConfig);
     return notificationMessage;
   }
 
@@ -206,12 +210,26 @@ public class PwaNotificationService {
 
   /**
    * Send a Push Notification to display to user device(s)
-   * 
+   *
    * @param webNotificationId
    */
   public ScheduledFuture<?> create(long webNotificationId) { // NOSONAR
     if (pwaManifestService.isPwaEnabled()) {
       return executorService.schedule(() -> this.sendCreateNotification(webNotificationId), 1, TimeUnit.SECONDS);
+    } else {
+      return null;
+    }
+  }
+
+
+  /**
+   * Send a Push Notification to display to user device(s)
+   *
+   * @param params
+   */
+  public ScheduledFuture<?> create(Map<String, Object> params) { // NOSONAR
+    if (pwaManifestService.isPwaEnabled()) {
+      return executorService.schedule(() -> this.sendNotification(params), 1, TimeUnit.SECONDS);
     } else {
       return null;
     }
@@ -240,36 +258,42 @@ public class PwaNotificationService {
     }
     String notificationId = notification.getId();
     String username = notification.getTo();
+    HashMap<String,Object> params = new HashMap<>();
+    params.put(EVENT_NOTIFICATION_ID_PARAM_NAME, Long.parseLong(notificationId));
+    params.put(EVENT_ACTION_PARAM_NAME, action);
     if (username != null) {
-      return sendNotification(Long.parseLong(notificationId), action, username);
+      params.put(EVENT_USERNAME_PARAM_NAME, username);
+      return sendNotification(params);
     } else if (notification.getSendToUserIds() != null) {
       return notification.getSendToUserIds()
                          .stream()
-                         .map(user -> sendNotification(Long.parseLong(notificationId), action, username))
+                         .map(user -> {
+                           params.put(EVENT_USERNAME_PARAM_NAME, user);
+                           return sendNotification(params);
+                         })
                          .reduce(0, Integer::sum);
     } else {
       return 0;
     }
   }
 
-  private int sendNotification(long notificationId, String action, String username) {
-    List<UserPushSubscription> subscriptions = pwaSubscriptionService.getSubscriptions(username);
+  private int sendNotification(Map<String, Object> params) {
+    String userName = params.get(EVENT_USERNAME_PARAM_NAME).toString();
+    List<UserPushSubscription> subscriptions = pwaSubscriptionService.getSubscriptions(userName);
     return subscriptions.stream()
                         .map(subscription -> {
                           long start = System.currentTimeMillis();
                           try {
-                            String payload = notificationId + ":" + action;
+                            String payload = params.get(EVENT_NOTIFICATION_ID_PARAM_NAME) + ":" + params.get(EVENT_ACTION_PARAM_NAME);
                             HttpResponse httpResponse = sendPushMessage(subscription, payload.getBytes());
                             StatusLine status = httpResponse.getStatusLine();
                             if (status.getStatusCode() == 410) {
                               // Outdated subscription
                               try {
-                                pwaSubscriptionService.deleteSubscription(subscription.getId(), username, false);
+                                pwaSubscriptionService.deleteSubscription(subscription.getId(), userName, false);
                               } finally {
                                 broadcastEvent(EVENT_OUTDATED_SUBSCRIPTION,
-                                               notificationId,
-                                               action,
-                                               username,
+                                               params,
                                                subscription,
                                                httpResponse,
                                                start,
@@ -277,18 +301,14 @@ public class PwaNotificationService {
                               }
                             } else if (status.getStatusCode() < 200 || status.getStatusCode() > 299) {
                               broadcastEvent(EVENT_NOTIFICATION_RESPONSE_ERROR,
-                                             notificationId,
-                                             action,
-                                             username,
+                                             params,
                                              subscription,
                                              httpResponse,
                                              start,
                                              null);
                             } else {
                               broadcastEvent(EVENT_NOTIFICATION_SENT,
-                                             notificationId,
-                                             action,
-                                             username,
+                                             params,
                                              subscription,
                                              httpResponse,
                                              start,
@@ -297,14 +317,12 @@ public class PwaNotificationService {
                             }
                           } catch (Exception e) {
                             LOG.warn("Error while sending push notification {} to user {}. Ignore reattempting and continue processing messages queue.",
-                                     notificationId,
-                                     username,
+                                     params.get(EVENT_NOTIFICATION_ID_PARAM_NAME),
+                                     userName,
                                      e);
 
                             broadcastEvent(EVENT_NOTIFICATION_SENDING_ERROR,
-                                           notificationId,
-                                           action,
-                                           username,
+                                           params,
                                            subscription,
                                            null,
                                            start,
@@ -325,8 +343,8 @@ public class PwaNotificationService {
     return pushService.send(notification);
   }
 
-  private void setDefaultNotificationMessageProperties(PwaNotificationMessage notificationMessage,
-                                                       NotificationInfo notification,
+  public void setDefaultNotificationMessageProperties(PwaNotificationMessage notificationMessage,
+                                                       String notificationId,
                                                        LocaleConfig localeConfig) {
     List<PwaNotificationAction> notificationActions = notificationMessage.getActions();
     if (CollectionUtils.isEmpty(notificationMessage.getActions())
@@ -344,7 +362,7 @@ public class PwaNotificationService {
     notificationMessage.setLang(localeConfig.getLanguage());
     notificationMessage.setDir(localeConfig.getOrientation() == null || localeConfig.getOrientation().isLT() ? "ltr" : "rtl");
     if (StringUtils.isBlank(notificationMessage.getTag())) {
-      notificationMessage.setTag(notification.getId());
+      notificationMessage.setTag(notificationId);
     }
     if (StringUtils.length(notificationMessage.getBody()) > maxBodyLength) {
       notificationMessage.setBody(notificationMessage.getBody().substring(0, maxBodyLength) + "...");
@@ -367,21 +385,16 @@ public class PwaNotificationService {
   }
 
   private void broadcastEvent(String eventName, // NOSONAR
-                              long notificationId,
-                              String action,
-                              String username,
+                              Map<String, Object> params,
                               UserPushSubscription subscription,
                               HttpResponse httpResponse,
                               long start,
                               String errorMessage) {
-    Map<String, Object> params = new HashMap<>();
     params.put(EVENT_SUBSCRIPTION_PARAM_NAME, subscription);
     params.put(EVENT_ERROR_PARAM_NAME, errorMessage);
-    params.put(EVENT_ACTION_PARAM_NAME, action);
     params.put(EVENT_DURATION_PARAM_NAME, (System.currentTimeMillis() - start));
-    params.put(EVENT_NOTIFICATION_ID_PARAM_NAME, notificationId);
     params.put(EVENT_HTTP_RESPONSE_PARAM_NAME, httpResponse);
-    listenerService.broadcast(eventName, username, params);
+    listenerService.broadcast(eventName, params.get(EVENT_USERNAME_PARAM_NAME), params);
   }
 
 }

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -95,6 +95,10 @@ public class PwaNotificationService {
 
   public static final String           EVENT_ACTION_PARAM_NAME                 = "action";
 
+  public static final String           EVENT_NOTIFICATION_TYPE_PARAM_NAME      = "type";
+
+  public static final String           WEB_NOTIFICATION                        = "WEB_NOTIFICATION";
+
   public static final String           EVENT_USERNAME_PARAM_NAME               = "username";
 
   public static final String           EVENT_DURATION_PARAM_NAME               = "duration";
@@ -159,8 +163,7 @@ public class PwaNotificationService {
 
   @PostConstruct
   public void init() {
-    ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("PWA-Push-Notification-%d")
-                                                            .build();
+    ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("PWA-Push-Notification-%d").build();
     executorService = Executors.newScheduledThreadPool(poolSize, threadFactory);
   }
 
@@ -221,7 +224,6 @@ public class PwaNotificationService {
     }
   }
 
-
   /**
    * Send a Push Notification to display to user device(s)
    *
@@ -258,9 +260,10 @@ public class PwaNotificationService {
     }
     String notificationId = notification.getId();
     String username = notification.getTo();
-    HashMap<String,Object> params = new HashMap<>();
+    HashMap<String, Object> params = new HashMap<>();
     params.put(EVENT_NOTIFICATION_ID_PARAM_NAME, Long.parseLong(notificationId));
     params.put(EVENT_ACTION_PARAM_NAME, action);
+    params.put(EVENT_NOTIFICATION_TYPE_PARAM_NAME, WEB_NOTIFICATION);
     if (username != null) {
       params.put(EVENT_USERNAME_PARAM_NAME, username);
       return sendNotification(params);
@@ -284,7 +287,11 @@ public class PwaNotificationService {
                         .map(subscription -> {
                           long start = System.currentTimeMillis();
                           try {
-                            String payload = params.get(EVENT_NOTIFICATION_ID_PARAM_NAME) + ":" + params.get(EVENT_ACTION_PARAM_NAME);
+                            String notificationType =
+                                                    StringUtils.isNotBlank((String) params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME)) ? (String) params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME)
+                                                                                                                                    : WEB_NOTIFICATION;
+                            String payload = notificationType + ":" + params.get(EVENT_NOTIFICATION_ID_PARAM_NAME) + ":"
+                                + params.get(EVENT_ACTION_PARAM_NAME);
                             HttpResponse httpResponse = sendPushMessage(subscription, payload.getBytes());
                             StatusLine status = httpResponse.getStatusLine();
                             if (status.getStatusCode() == 410) {
@@ -307,12 +314,15 @@ public class PwaNotificationService {
                                              start,
                                              null);
                             } else {
-                              broadcastEvent(EVENT_NOTIFICATION_SENT,
-                                             params,
-                                             subscription,
-                                             httpResponse,
-                                             start,
-                                             null);
+                              // Other push notifications managed by specific application should create their own statistics
+                              if(params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME).equals(WEB_NOTIFICATION)) {
+                                broadcastEvent(EVENT_NOTIFICATION_SENT,
+                                        params,
+                                        subscription,
+                                        httpResponse,
+                                        start,
+                                        null);
+                              }
                               return 1;
                             }
                           } catch (Exception e) {

--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -165,40 +165,7 @@ self.addEventListener('push', event => {
           }).then(resp => resp.ok && resp.json());
           if (webNotification) {
             const title = webNotification.title || '';
-            delete webNotification.title;
-            webNotification.icon = webNotification.icon || webNotification.image || self.location.origin + '/pwa/rest/manifest/smallIcon?sizes=72x72';
-            webNotification.data = {
-              notificationId,
-              url: self.location.origin + (webNotification.url || '/'),
-            };
-            delete webNotification.url;
-            if (!webNotification.tag) {
-              delete webNotification.tag;
-              delete webNotification.renotify;
-            }
-            if (!webNotification.image) {
-              delete webNotification.image;
-            }
-            if (!webNotification.lang) {
-              delete webNotification.lang;
-            }
-            if (!webNotification.dir) {
-              delete webNotification.dir;
-            }
-            if (!webNotification.body) {
-              delete webNotification.body;
-            }
-            if (!webNotification.vibrate) {
-              delete webNotification.vibrate;
-            }
-            if (!webNotification.badge) {
-              delete webNotification.badge;
-            }
-            if (!Notification.maxActions || !webNotification.actions) {
-              delete webNotification.actions;
-            } else if (webNotification.actions.length > Notification.maxActions) {
-              webNotification.actions = webNotification.actions.slice(0, Notification.maxActions);
-            }
+            prepareNotificationToSend(notificationId, webNotification)
             await self.registration.showNotification(title, webNotification);
             await refreshBadge();
           }
@@ -307,6 +274,44 @@ async function refreshBadge() {
       await navigator?.clearAppBadge?.();
     }
   }
+}
+
+function prepareNotificationToSend(notificationId, webNotification) {
+  delete webNotification.title;
+  webNotification.icon = webNotification.icon || webNotification.image || self.location.origin + '/pwa/rest/manifest/smallIcon?sizes=72x72';
+  webNotification.data = {
+    notificationId,
+    url: self.location.origin + (webNotification.url || '/'),
+  };
+  delete webNotification.url;
+  if (!webNotification.tag) {
+    delete webNotification.tag;
+    delete webNotification.renotify;
+  }
+  if (!webNotification.image) {
+    delete webNotification.image;
+  }
+  if (!webNotification.lang) {
+    delete webNotification.lang;
+  }
+  if (!webNotification.dir) {
+    delete webNotification.dir;
+  }
+  if (!webNotification.body) {
+    delete webNotification.body;
+  }
+  if (!webNotification.vibrate) {
+    delete webNotification.vibrate;
+  }
+  if (!webNotification.badge) {
+    delete webNotification.badge;
+  }
+  if (!Notification.maxActions || !webNotification.actions) {
+    delete webNotification.actions;
+  } else if (webNotification.actions.length > Notification.maxActions) {
+    webNotification.actions = webNotification.actions.slice(0, Notification.maxActions);
+  }
+  return webNotification;
 }
 
 @service-worker-extensions@

--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -154,27 +154,31 @@ if (offlineModeEnabled) {
 self.addEventListener('push', event => {
   if (self?.Notification?.permission === 'granted') {
     const data = event?.data?.text?.() || {};
-    const action = data.split(':')[1]
-    event.waitUntil(new Promise(async (resolve, reject) => {
-      try {
-        if (action === 'open') {
-          const notificationId = data.split(':')[0]
-          const webNotification = await fetch(`/pwa/rest/notifications/${notificationId}`, {
-            method: 'GET',
-            credentials: 'include',
-          }).then(resp => resp.ok && resp.json());
-          if (webNotification) {
-            const title = webNotification.title || '';
-            prepareNotificationToSend(notificationId, webNotification)
-            await self.registration.showNotification(title, webNotification);
-            await refreshBadge();
+    const params = data.split(':');
+    const notificationType = params[0];
+    if(notificationType === 'WEB_NOTIFICATION') {
+      const action = params[2]
+      event.waitUntil(new Promise(async (resolve, reject) => {
+        try {
+          if (action === 'open') {
+            const notificationId = params[1]
+            const webNotification = await fetch(`/pwa/rest/notifications/${notificationId}`, {
+              method: 'GET',
+              credentials: 'include',
+            }).then(resp => resp.ok && resp.json());
+            if (webNotification) {
+              const title = webNotification.title || '';
+              prepareNotificationToSend(notificationId, webNotification)
+              await self.registration.showNotification(title, webNotification);
+              await refreshBadge();
+            }
           }
+          resolve();
+        } catch (e) {
+          reject(e);
         }
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    }));
+      }));
+    }
   }
 });
 

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
@@ -201,7 +201,7 @@ public class PwaNotificationServiceTest {
     assertNotNull(future);
     assertEquals(0, (int) future.get());
     verify(pwaSubscriptionService, never()).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-    verify(pushService).send(argThat(n -> (NOTIFICATION_ID + ":" +
+    verify(pushService).send(argThat(n -> ("WEB_NOTIFICATION" + ":" + NOTIFICATION_ID + ":" +
         PWA_NOTIFICATION_OPEN_UI_ACTION).equals(new String(n.getPayload()))));
 
     when(statusLine.getStatusCode()).thenReturn(410);

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
@@ -18,8 +18,7 @@
  */
 package io.meeds.pwa.service;
 
-import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_MARK_READ_USER_ACTION;
-import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_OPEN_UI_ACTION;
+import static io.meeds.pwa.service.PwaNotificationService.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,7 +32,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
 import org.apache.http.HttpResponse;
@@ -214,6 +215,22 @@ public class PwaNotificationServiceTest {
     assertNotNull(future);
     assertEquals(1, (int) future.get());
     verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
+  }
+
+  @Test
+  public void createWithHashmap() throws Exception { // NOSONAR
+    ScheduledFuture<?> future = pwaNotificationService.create(new HashMap<>());
+    assertNull(future);
+    when(pwaManifestService.isPwaEnabled()).thenReturn(true);
+
+    Map<String, Object> params = new HashMap<>();
+    params.put(EVENT_NOTIFICATION_ID_PARAM_NAME, NOTIFICATION_ID);
+    params.put(EVENT_ACTION_PARAM_NAME, "open");
+    params.put(EVENT_USERNAME_PARAM_NAME, "john");
+    future = pwaNotificationService.create(params);
+    assertNotNull(future);
+    assertEquals(0, (int) future.get());
+    verifyNoInteractions(listenerService);
   }
 
   @SneakyThrows

--- a/pwa-webapp/package-lock.json
+++ b/pwa-webapp/package-lock.json
@@ -5288,9 +5288,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
A function added to create a new Push notification, based on a map of properties instead of using the identifier of a web notification.
This will allow to send notifications with their proper identifiers and load those notification using the service worker JS extensions.