### PR TITLE
fix: restore a deleted param in service-worker - MEED-9527 - Meeds-io/MIPs#189

### DIFF
--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -184,6 +184,7 @@ self.addEventListener('push', event => {
 });
 
 self.addEventListener('notificationclick', event => {
+  const url = event.notification.data.url;
   const notificationType = event?.notification?.data?.type;
   event.waitUntil(new Promise(async (resolve) => {
     event.notification.close();


### PR DESCRIPTION
In previous feature implementation, the parameter was deleted by error. This fix will restore it