### PR TITLE
fix: update pwa manifest to be able to use pwabuilder - MEED-10069 - meeds-io/meeds#3940

### DIFF
--- a/pwa-service/src/main/resources/pwa/manifest.json
+++ b/pwa-service/src/main/resources/pwa/manifest.json
@@ -11,6 +11,11 @@
     "sizes": "1024x1024",
     "type": "image/png",
     "purpose": "maskable"
+  },{
+    "src": "$largeIconPath/512.png",
+    "sizes": "512x512",
+    "type": "image/png",
+    "purpose": "maskable"
   }, {
     "src": "$largeIconPath&sizes=192x192",
     "sizes": "192x192",


### PR DESCRIPTION
Before this fix, icons url in pwa manifest are rest service call with query params. When using PWABuilder, it prevent to load correctly icons As we need this tool to prepare mobile application package, this commit change the rest endpoint to a endpoint without queryParam The size of the image is used as PathParam.

Resolves meeds-io/meeds#3940

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
