### PR TITLE
fix: update pwa manifest to be able to use pwabuilder - MEED-10069 - meeds-io/meeds#3940

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
@@ -31,6 +31,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,6 +50,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 @RestController
 @RequestMapping("manifest")
@@ -94,25 +98,24 @@ public class PwaManifestRest {
     pwaManifestService.updateManifest(manifestUpdate, request.getRemoteUser());
   }
 
-  @GetMapping("/largeIcon")
+  @GetMapping("/largeIcon/{size}.png")
   @Operation(summary = "Get PWA Manifest large icon file", description = "Get PWA Manifest large icon file", method = "GET")
   @ApiResponses(value = {
                           @ApiResponse(responseCode = "200", description = "Icon file retrieved"),
                           @ApiResponse(responseCode = "304", description = "Icon file not modified"),
   })
-  public ResponseEntity<InputStreamResource> getManifestLargeIcon(
-                                                                  WebRequest request,
-                                                                  @Parameter(description = "Dimensions of size")
-                                                                  @RequestParam(name = "sizes", required = false)
-                                                                  String sizes) {
-    InputStream inputStream = getBrandingFileResponse(request, pwaManifestService.getLargeIcon(sizes));
+  public ResponseEntity<InputStreamResource> getManifestLargeIcon(WebRequest request,
+                                                                  @Parameter(description = "Dimensions of size", required = true)
+                                                                  @PathVariable("size") String size) {
+    String realSize= size+"x"+size;
+    InputStream inputStream = getBrandingFileResponse(request, pwaManifestService.getLargeIcon(realSize));
     return inputStream == null ? null :
                                ResponseEntity.ok()
                                              .contentType(MediaType.IMAGE_PNG)
                                              .body(new InputStreamResource(inputStream));
   }
 
-  @GetMapping("/smallIcon")
+  @GetMapping("/smallIcon/{size}.png")
   @Operation(summary = "Get PWA Manifest small icon file", description = "Get PWA Manifest small icon file", method = "GET")
   @ApiResponses(value = {
                           @ApiResponse(responseCode = "200", description = "Icon file retrieved"),
@@ -120,10 +123,11 @@ public class PwaManifestRest {
   })
   public ResponseEntity<InputStreamResource> getManifestSmallIcon(
                                                                   WebRequest request,
-                                                                  @Parameter(description = "Dimensions of size")
-                                                                  @RequestParam(name = "sizes", required = false)
-                                                                  String sizes) {
-    InputStream inputStream = getBrandingFileResponse(request, pwaManifestService.getSmallIcon(sizes));
+                                                                  @Parameter(description = "Dimensions of size", required = true)
+                                                                  @PathVariable("size")
+                                                                  String size) {
+    String realSize= size+"x"+size;
+    InputStream inputStream = getBrandingFileResponse(request, pwaManifestService.getSmallIcon(realSize));
     return inputStream == null ? null :
                                ResponseEntity.ok()
                                              .contentType(MediaType.IMAGE_PNG)

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaManifestService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaManifestService.java
@@ -84,9 +84,9 @@ public class PwaManifestService {
 
   public static final String      DEPRECATED_PUSH_CHANNEL_ID = "PUSH_CHANNEL";
 
-  public static final String      PWA_LARGE_ICON_BASE_PATH   = "/pwa/rest/manifest/largeIcon?v=";               // NOSONAR
+  public static final String      PWA_LARGE_ICON_BASE_PATH   = "/pwa/rest/manifest/largeIcon";               // NOSONAR
 
-  public static final String      PWA_SMALL_ICON_BASE_PATH   = "/pwa/rest/manifest/smallIcon?v=";               // NOSONAR
+  public static final String      PWA_SMALL_ICON_BASE_PATH   = "/pwa/rest/manifest/smallIcon";               // NOSONAR
 
   public static final String      FILE_API_NAME_SPACE        = "CompanyBranding";
 
@@ -311,12 +311,12 @@ public class PwaManifestService {
 
   public String getLargeIconPath() {
     ManifestIcon manifestIcon = getLargeIcon();
-    return manifestIcon == null ? null : PWA_LARGE_ICON_BASE_PATH + Objects.hash(manifestIcon.getUpdatedDate());
+    return manifestIcon == null ? null : PWA_LARGE_ICON_BASE_PATH;
   }
 
   public String getSmallIconPath() {
     ManifestIcon manifestIcon = getSmallIcon();
-    return manifestIcon == null ? null : PWA_SMALL_ICON_BASE_PATH + Objects.hash(manifestIcon.getUpdatedDate());
+    return manifestIcon == null ? null : PWA_SMALL_ICON_BASE_PATH;
   }
 
   public void refreshManifest() {

--- a/pwa-service/src/main/resources/pwa/manifest.json
+++ b/pwa-service/src/main/resources/pwa/manifest.json
@@ -7,7 +7,7 @@
   "description": "$description",
   "shortcuts": $shortcuts,
   "icons": [{
-    "src": "$largeIconPath&sizes=1024x1024",
+    "src": "$largeIconPath/1024.png",
     "sizes": "1024x1024",
     "type": "image/png",
     "purpose": "maskable"
@@ -17,16 +17,16 @@
     "type": "image/png",
     "purpose": "maskable"
   }, {
-    "src": "$largeIconPath&sizes=192x192",
+    "src": "$largeIconPath/192.png",
     "sizes": "192x192",
     "type": "image/png",
     "purpose": "any"
   }, {
-    "src": "$smallIconPath&sizes=144x144",
+    "src": "$smallIconPath/144.png",
     "sizes": "144x144",
     "type": "image/png"
   }, {
-    "src": "$smallIconPath&sizes=72x72",
+    "src": "$smallIconPath/72.png",
     "sizes": "72x72",
     "type": "image/png"
   }],


### PR DESCRIPTION
Before this fix, icons url in pwa manifest are rest service call with query params. When using PWABuilder, it prevent to load correctly icons As we need this tool to prepare mobile application package, this commit change the rest endpoint to a endpoint without queryParam The size of the image is used as PathParam.

Resolves https://github.com/Meeds-io/meeds/issues/3940