### PR TITLE
fix: add a version in the icon url as pathParam - MEED-10069 - meeds-io/meeds#3940

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
@@ -98,7 +98,7 @@ public class PwaManifestRest {
     pwaManifestService.updateManifest(manifestUpdate, request.getRemoteUser());
   }
 
-  @GetMapping("/largeIcon/{size}.png")
+  @GetMapping("/largeIcon/{version}/{size}.png")
   @Operation(summary = "Get PWA Manifest large icon file", description = "Get PWA Manifest large icon file", method = "GET")
   @ApiResponses(value = {
                           @ApiResponse(responseCode = "200", description = "Icon file retrieved"),
@@ -106,7 +106,9 @@ public class PwaManifestRest {
   })
   public ResponseEntity<InputStreamResource> getManifestLargeIcon(WebRequest request,
                                                                   @Parameter(description = "Dimensions of size", required = true)
-                                                                  @PathVariable("size") String size) {
+                                                                  @PathVariable("size") String size,
+                                                                  @Parameter(description = "VersionId of the icon", required = true)
+                                                                  @PathVariable("version") String version) {
     String realSize= size+"x"+size;
     InputStream inputStream = getBrandingFileResponse(request, pwaManifestService.getLargeIcon(realSize));
     return inputStream == null ? null :
@@ -115,7 +117,7 @@ public class PwaManifestRest {
                                              .body(new InputStreamResource(inputStream));
   }
 
-  @GetMapping("/smallIcon/{size}.png")
+  @GetMapping("/smallIcon/{version}/{size}.png")
   @Operation(summary = "Get PWA Manifest small icon file", description = "Get PWA Manifest small icon file", method = "GET")
   @ApiResponses(value = {
                           @ApiResponse(responseCode = "200", description = "Icon file retrieved"),
@@ -125,7 +127,9 @@ public class PwaManifestRest {
                                                                   WebRequest request,
                                                                   @Parameter(description = "Dimensions of size", required = true)
                                                                   @PathVariable("size")
-                                                                  String size) {
+                                                                  String size,
+                                                                  @Parameter(description = "VersionId of the icon", required = true)
+                                                                  @PathVariable("version") String version) {
     String realSize= size+"x"+size;
     InputStream inputStream = getBrandingFileResponse(request, pwaManifestService.getSmallIcon(realSize));
     return inputStream == null ? null :

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaManifestService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaManifestService.java
@@ -311,12 +311,12 @@ public class PwaManifestService {
 
   public String getLargeIconPath() {
     ManifestIcon manifestIcon = getLargeIcon();
-    return manifestIcon == null ? null : PWA_LARGE_ICON_BASE_PATH;
+    return manifestIcon == null ? null : PWA_LARGE_ICON_BASE_PATH + "/" + Objects.hash(manifestIcon.getUpdatedDate());
   }
 
   public String getSmallIconPath() {
     ManifestIcon manifestIcon = getSmallIcon();
-    return manifestIcon == null ? null : PWA_SMALL_ICON_BASE_PATH;
+    return manifestIcon == null ? null : PWA_SMALL_ICON_BASE_PATH + "/" + Objects.hash(manifestIcon.getUpdatedDate());
   }
 
   public void refreshManifest() {


### PR DESCRIPTION
Before this fix, the last commit remove the version parameter in the icons url for pwa, then if the icon change, the cache prevent the application to see the new icon This commit ensure to use the versionId in the url, as pathParam

Resolves meeds-io/meeds#3940

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
