### PR TITLE
[PWA - Android] Top bar containing application url is displayed - meeds-io/meeds#4038 - MEED-10207

### DIFF
--- a/pwa-service/src/main/resources/pwa/manifest.json
+++ b/pwa-service/src/main/resources/pwa/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "/",
-  "start_url": "/",
+  "start_url": "/pwa/html/pwaLauncher.html",
   "scope": "/",
   "name": "$name",
   "short_name": "$name",

--- a/pwa-webapp/src/main/webapp/html/pwaLauncher.html
+++ b/pwa-webapp/src/main/webapp/html/pwaLauncher.html
@@ -1,0 +1,3 @@
+<script>
+    window.location.replace('/');
+</script>


### PR DESCRIPTION
Before this fix the top is displayed because this application is not considered as Trusted Web Activity (TWA) This is due to the initial redirection on url configured in startUrl in manifest This commit add a land page for PWA app, which ensure to answer an http 200, and after that, only make the redirection on '/'

Resolves meeds-io/meeds#4038

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
