### PR TITLE
feat: Avoid Marking as read Web Notif when Closing Desktop Notif - EXO-87243

### DIFF
--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -230,29 +230,17 @@ self.addEventListener('notificationclick', event => {
     } catch(e) {
       console.error(e);
     } finally {
-      await handleClose(notificationId);
+      await markAsRead(notificationId);
       resolve();
     }
   }));
 });
 
 self.addEventListener('notificationclose', event => {
-  const notificationType = event?.notification?.data?.type;
-  if(!notificationType || notificationType === 'WEB_NOTIFICATION') {
-    const notificationId = event?.notification?.data?.notificationId || event?.notification?.tag;
-    if (notificationId) {
-      event.waitUntil(new Promise(async (resolve) => {
-        try {
-          await handleClose(notificationId);
-        } finally {
-          resolve();
-        }
-      }));
-    }
-  }
+  event.waitUntil(refreshBadge);
 });
 
-async function handleClose(notificationId) {
+async function markAsRead(notificationId) {
   try {
     await updateNotification(notificationId, 'markRead');
   } catch(e) {


### PR DESCRIPTION
Prior to this change, when closing the Desktop Notification, the Web Notification is marked as read as well. This change ensures to keep the Web Notification as is when the user didn't click on 'Mark As Read' quick action from Desktop Notif or opening the notification.