### PR TITLE
feat: Allow to access Web Notification when session is timedout - EXO-87327

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/model/UserPushSubscription.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/model/UserPushSubscription.java
@@ -46,6 +46,8 @@ public class UserPushSubscription {
 
   private String deviceType;
 
+  private String pushDeviceSecret;
+
   public byte[] authAsBytes() {
     return Base64.getDecoder().decode(getAuth());
   }

--- a/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/PwaManifestRest.java
@@ -51,9 +51,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-
 @RestController
 @RequestMapping("manifest")
 @Tag(name = "manifest", description = "Managing PWA Manifest")

--- a/pwa-service/src/main/java/io/meeds/pwa/rest/PwaNotificationRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/PwaNotificationRest.java
@@ -25,6 +25,7 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -63,6 +64,53 @@ public class PwaNotificationRest {
                                                 long notificationId) {
     try {
       return pwaNotificationService.getNotification(notificationId, request.getRemoteUser());
+    } catch (ObjectNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    } catch (IllegalAccessException e) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());
+    }
+  }
+
+  @GetMapping("{id}/push")
+  @Operation(summary = "Get Web Notification from push token",
+             description = "Get Web Notification from push token",
+             method = "GET")
+  @ApiResponses(value = {
+                          @ApiResponse(responseCode = "200", description = "Web Notification retrieved"),
+  })
+  public PwaNotificationMessage getNotificationFromPush(
+                                                        @Parameter(description = "The Web Notification Identifier")
+                                                        @PathVariable("id")
+                                                        long notificationId,
+                                                        @RequestHeader(value = "Authorization", required = false)
+                                                        String authorizationHeader) {
+    try {
+      return pwaNotificationService.getNotificationFromPush(notificationId, authorizationHeader);
+    } catch (ObjectNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    } catch (IllegalAccessException e) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());
+    }
+  }
+
+  @PatchMapping(path = "{id}/push", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+  @Operation(summary = "Update Web Notification from push token",
+             description = "Update Web Notification from push token",
+             method = "PATCH")
+  @ApiResponses(value = {
+                          @ApiResponse(responseCode = "204", description = "Web Notification updated"),
+  })
+  public void updateNotificationPropertyFromPush(
+                                                 @Parameter(description = "The Web Notification Identifier")
+                                                 @PathVariable("id")
+                                                 long notificationId,
+                                                 @Parameter(description = "The Web Notification action")
+                                                 @RequestParam("action")
+                                                 String action,
+                                                 @RequestHeader(value = "Authorization", required = false)
+                                                 String authorizationHeader) {
+    try {
+      pwaNotificationService.updateNotificationFromPush(notificationId, action, authorizationHeader);
     } catch (ObjectNotFoundException e) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
     } catch (IllegalAccessException e) {

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaManifestService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaManifestService.java
@@ -90,9 +90,9 @@ public class PwaManifestService {
 
   public static final String      DEPRECATED_PUSH_CHANNEL_ID = "PUSH_CHANNEL";
 
-  public static final String      PWA_LARGE_ICON_BASE_PATH   = "/pwa/rest/manifest/largeIcon";               // NOSONAR
+  public static final String      PWA_LARGE_ICON_BASE_PATH   = "/pwa/rest/manifest/largeIcon";                  // NOSONAR
 
-  public static final String      PWA_SMALL_ICON_BASE_PATH   = "/pwa/rest/manifest/smallIcon";               // NOSONAR
+  public static final String      PWA_SMALL_ICON_BASE_PATH   = "/pwa/rest/manifest/smallIcon";                  // NOSONAR
 
   public static final String      FILE_API_NAME_SPACE        = "CompanyBranding";
 
@@ -178,7 +178,7 @@ public class PwaManifestService {
 
   private ManifestIcon            smallIcon                  = null;
 
-  private ManifestIcon            monochromeIcon                  = null;
+  private ManifestIcon            monochromeIcon             = null;
 
   @PostConstruct
   @ContainerTransactional
@@ -576,7 +576,8 @@ public class PwaManifestService {
     return this.monochromeIcon;
   }
 
-  public byte[] convertToMonochrome(byte[] inputBytes) throws Exception {
+  @SneakyThrows
+  public byte[] convertToMonochrome(byte[] inputBytes) {
     BufferedImage input;
 
     try (ByteArrayInputStream bais = new ByteArrayInputStream(inputBytes)) {

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -18,16 +18,21 @@
  */
 package io.meeds.pwa.service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -43,8 +48,6 @@ import org.exoplatform.commons.api.notification.service.WebNotificationService;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.portal.Constants;
 import org.exoplatform.services.listener.ListenerService;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.UserProfile;
 import org.exoplatform.services.resources.LocaleConfig;
@@ -60,11 +63,21 @@ import io.meeds.pwa.storage.PwaNotificationStorage;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
 import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
 
 @Service
+@Slf4j
 public class PwaNotificationService {
+
+  public static final String           PROOF_PARAM                             = "proof";
+
+  public static final String           TIMESTAMP_PARAM                         = "timestamp";
+
+  public static final String           SUBSCRIPTION_ID_PARAM                   = "subscriptionId";
+
+  public static final String           PUSH_TOKEN_PARAM                        = "token";
 
   public static final String           PWA_NOTIFICATION_CREATED                = "pwa.notification.created";
 
@@ -72,7 +85,8 @@ public class PwaNotificationService {
 
   public static final String           PWA_NOTIFICATION_MARK_READ_USER_ACTION  = "markRead";
 
-  public static final String           PWA_NOTIFICATION_MARK_READ_ACTION_LABEL = "pwa.notification.action.markAsRead";
+  public static final String           PWA_NOTIFICATION_MARK_READ_ACTION_LABEL =
+                                                                               "pwa.notification.action.markAsRead";
 
   public static final String           EVENT_NOTIFICATION_SENT                 = "pwa.notificationSent";
 
@@ -100,10 +114,13 @@ public class PwaNotificationService {
 
   public static final String           EVENT_DURATION_PARAM_NAME               = "duration";
 
-  public static final Random           RANDOM                                  = new Random();
+  public static final String           EVENT_NOTIFICATION_TOKEN_PARAM_NAME     = PUSH_TOKEN_PARAM;
 
-  private static final Log             LOG                                     =
-                                           ExoLogger.getLogger(PwaNotificationService.class);
+  public static final String           EVENT_SUBSCRIPTION_ID_PARAM_NAME        = SUBSCRIPTION_ID_PARAM;
+
+  private static final String          PUSH_AUTH_SCHEME                        = "PWA-Notification";
+
+  private static final String          HMAC_ALGORITHM                          = "HmacSHA256";
 
   @Autowired
   private PwaManifestService           pwaManifestService;
@@ -135,6 +152,9 @@ public class PwaNotificationService {
   @Autowired
   private PushService                  pushService;
 
+  @Autowired
+  private PwaNotificationTokenService  pwaNotificationTokenService;
+
   @Value("${pwa.notifications.enabled:true}")
   private boolean                      enabled;
 
@@ -152,6 +172,9 @@ public class PwaNotificationService {
 
   @Value("${pwa.notifications.silent:false}")
   private boolean                      silent;
+
+  @Value("${pwa.notifications.push.token.ttl.seconds:28800}") // 8 hours
+  private int                          pushTokenTtlSeconds;
 
   @Autowired
   private List<PwaNotificationPlugin>  plugins;
@@ -187,6 +210,21 @@ public class PwaNotificationService {
     PwaNotificationMessage notificationMessage = notificationPlugin.process(notification, localeConfig);
     setDefaultNotificationMessageProperties(notificationMessage, notification.getId(), localeConfig);
     return notificationMessage;
+  }
+
+  public PwaNotificationMessage getNotificationFromPush(long webNotificationId,
+                                                        String authorizationHeader) throws ObjectNotFoundException,
+                                                                                    IllegalAccessException {
+    String username = validatePushNotificationAccess(webNotificationId, authorizationHeader);
+    return getNotification(webNotificationId, username);
+  }
+
+  public void updateNotificationFromPush(long webNotificationId,
+                                         String action,
+                                         String authorizationHeader) throws ObjectNotFoundException,
+                                                                     IllegalAccessException {
+    String username = validatePushNotificationAccess(webNotificationId, authorizationHeader);
+    updateNotification(webNotificationId, action, username);
   }
 
   public void updateNotification(long webNotificationId, String action, String username) throws ObjectNotFoundException,
@@ -253,7 +291,7 @@ public class PwaNotificationService {
 
   private int sendNotification(NotificationInfo notification, String action) {
     if (notification == null) {
-      LOG.warn("Can't send notification action {} since notification is null", action);
+      log.warn("Can't send notification action {} since notification is null", action);
       return 0;
     }
     String notificationId = notification.getId();
@@ -278,7 +316,7 @@ public class PwaNotificationService {
     }
   }
 
-  private int sendNotification(Map<String, Object> params) {
+  private int sendNotification(Map<String, Object> params) { // NOSONAR
     String userName = params.get(EVENT_USERNAME_PARAM_NAME).toString();
     List<UserPushSubscription> subscriptions = pwaSubscriptionService.getSubscriptions(userName);
     return subscriptions.stream()
@@ -286,10 +324,18 @@ public class PwaNotificationService {
                           long start = System.currentTimeMillis();
                           try {
                             String notificationType =
-                                                    StringUtils.isNotBlank((String) params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME)) ? (String) params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME)
-                                                                                                                                    : WEB_NOTIFICATION;
-                            String payload = notificationType + ":" + params.get(EVENT_NOTIFICATION_ID_PARAM_NAME) + ":"
-                                + params.get(EVENT_ACTION_PARAM_NAME);
+                                                    StringUtils.isNotBlank((String) params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME)) ?
+                                                                                                                                    (String) params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME) :
+                                                                                                                                    WEB_NOTIFICATION;
+                            String payload = "%s:%s:%s".formatted(notificationType,
+                                                                  params.get(EVENT_NOTIFICATION_ID_PARAM_NAME),
+                                                                  params.get(EVENT_ACTION_PARAM_NAME));
+                            if (StringUtils.equals(notificationType, WEB_NOTIFICATION)) {
+                              String pushToken = generatePushNotificationAccessToken(params, subscription);
+                              if (StringUtils.isNotBlank(pushToken)) {
+                                payload += ":%s:%s".formatted(pushToken, subscription.getId());
+                              }
+                            }
                             HttpResponse httpResponse = sendPushMessage(subscription, payload.getBytes());
                             StatusLine status = httpResponse.getStatusLine();
                             if (status.getStatusCode() == 410) {
@@ -312,19 +358,20 @@ public class PwaNotificationService {
                                              start,
                                              null);
                             } else {
-                              // Other push notifications managed by specific application should create their own statistics
-                              if(params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME).equals(WEB_NOTIFICATION)) {
+                              // Other push notifications managed by specific
+                              // application should create their own statistics
+                              if (params.get(EVENT_NOTIFICATION_TYPE_PARAM_NAME).equals(WEB_NOTIFICATION)) {
                                 broadcastEvent(EVENT_NOTIFICATION_SENT,
-                                        params,
-                                        subscription,
-                                        httpResponse,
-                                        start,
-                                        null);
+                                               params,
+                                               subscription,
+                                               httpResponse,
+                                               start,
+                                               null);
                               }
                               return 1;
                             }
                           } catch (Exception e) {
-                            LOG.warn("Error while sending push notification {} to user {}. Ignore reattempting and continue processing messages queue.",
+                            log.warn("Error while sending push notification {} to user {}. Ignore reattempting and continue processing messages queue.",
                                      params.get(EVENT_NOTIFICATION_ID_PARAM_NAME),
                                      userName,
                                      e);
@@ -342,18 +389,95 @@ public class PwaNotificationService {
   }
 
   private HttpResponse sendPushMessage(UserPushSubscription sub, byte[] payload) throws Exception { // NOSONAR
-    Notification notification = new Notification(
-                                                 sub.getEndpoint(),
+    Notification notification = new Notification(sub.getEndpoint(),
                                                  sub.userPublicKey(),
                                                  sub.authAsBytes(),
-                                                 payload);
+                                                 payload,
+                                                 pushTokenTtlSeconds);
     // Send the notification
     return pushService.send(notification);
   }
 
+  private String generatePushNotificationAccessToken(Map<String, Object> params, UserPushSubscription subscription) {
+    if (subscription == null || StringUtils.isBlank(subscription.getId())
+        || StringUtils.isBlank(subscription.getPushDeviceSecret())) {
+      return null;
+    }
+    String username = String.valueOf(params.get(EVENT_USERNAME_PARAM_NAME));
+    long notificationId = Long.parseLong(String.valueOf(params.get(EVENT_NOTIFICATION_ID_PARAM_NAME)));
+    return pwaNotificationTokenService.createToken(username, notificationId, subscription.getId());
+  }
+
+  private String validatePushNotificationAccess(long notificationId, String authorizationHeader) throws IllegalAccessException {
+    Map<String, String> parameters = parsePushAuthorizationHeader(authorizationHeader);
+    String token = parameters.get(PUSH_TOKEN_PARAM);
+    String subscriptionId = parameters.get(SUBSCRIPTION_ID_PARAM);
+    String timestamp = parameters.get(TIMESTAMP_PARAM);
+    String proof = parameters.get(PROOF_PARAM);
+    if (StringUtils.isAnyBlank(token, subscriptionId, timestamp, proof)) {
+      throw new IllegalAccessException("Missing push authorization parameters");
+    }
+    long timestampValue;
+    try {
+      timestampValue = Long.parseLong(timestamp);
+    } catch (NumberFormatException e) {
+      throw new IllegalAccessException("Invalid push authorization timestamp");
+    }
+    long now = System.currentTimeMillis();
+    if (Math.abs(now - timestampValue) > TimeUnit.SECONDS.toMillis(pushTokenTtlSeconds)) {
+      throw new IllegalAccessException("Expired push authorization proof");
+    }
+    String username = pwaNotificationTokenService.validateToken(token, notificationId, subscriptionId);
+    if (StringUtils.isBlank(username)) {
+      throw new IllegalAccessException("Invalid push notification token");
+    }
+    UserPushSubscription subscription = pwaSubscriptionService.getSubscription(username, subscriptionId);
+    if (subscription == null || StringUtils.isBlank(subscription.getPushDeviceSecret())) {
+      throw new IllegalAccessException("Unknown push subscription");
+    }
+    String expectedProof = computeHmac(subscription.getPushDeviceSecret(),
+                                       notificationId + ":" + token + ":" + subscriptionId + ":" + timestamp);
+    if (!MessageDigest.isEqual(expectedProof.getBytes(StandardCharsets.UTF_8), proof.getBytes(StandardCharsets.UTF_8))) {
+      throw new IllegalAccessException("Invalid push authorization proof");
+    }
+    String consumedUsername = pwaNotificationTokenService.consumeToken(token, notificationId, subscriptionId);
+    if (!StringUtils.equals(username, consumedUsername)) {
+      throw new IllegalAccessException("Push notification token already consumed");
+    }
+    return username;
+  }
+
+  private Map<String, String> parsePushAuthorizationHeader(String authorizationHeader) throws IllegalAccessException {
+    if (StringUtils.isBlank(authorizationHeader) || !StringUtils.startsWith(authorizationHeader, PUSH_AUTH_SCHEME + " ")) {
+      throw new IllegalAccessException("Missing push authorization header");
+    }
+    Map<String, String> parameters = new HashMap<>();
+    String[] parts = StringUtils.substringAfter(authorizationHeader, PUSH_AUTH_SCHEME + " ").split(",");
+    for (String part : parts) {
+      String key = StringUtils.trim(StringUtils.substringBefore(part, "="));
+      String value = StringUtils.trim(StringUtils.substringAfter(part, "="));
+      value = StringUtils.removeStart(value, "\"");
+      value = StringUtils.removeEnd(value, "\"");
+      if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)) {
+        parameters.put(key, value);
+      }
+    }
+    return parameters;
+  }
+
+  private String computeHmac(String secret, String value) throws IllegalAccessException {
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(new SecretKeySpec(Base64.getDecoder().decode(secret), HMAC_ALGORITHM));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception e) {
+      throw new IllegalAccessException("Unable to compute push authorization proof");
+    }
+  }
+
   public void setDefaultNotificationMessageProperties(PwaNotificationMessage notificationMessage,
-                                                       String notificationId,
-                                                       LocaleConfig localeConfig) {
+                                                      String notificationId,
+                                                      LocaleConfig localeConfig) {
     List<PwaNotificationAction> notificationActions = notificationMessage.getActions();
     if (CollectionUtils.isEmpty(notificationMessage.getActions())
         || notificationActions.stream()
@@ -387,7 +511,7 @@ public class PwaNotificationService {
       return language == null ? localeConfigService.getDefaultLocaleConfig() : localeConfigService.getLocaleConfig(language);
     } catch (Exception e) {
       LocaleConfig defaultLocaleConfig = localeConfigService.getDefaultLocaleConfig();
-      LOG.warn("Error retrieving user {} language, use default language {}", username, defaultLocaleConfig.getLanguage());
+      log.warn("Error retrieving user {} language, use default language {}", username, defaultLocaleConfig.getLanguage());
       return defaultLocaleConfig;
     }
   }

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationTokenService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationTokenService.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.pwa.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.container.xml.ValuesParam;
+import org.exoplatform.web.security.PortalToken;
+import org.exoplatform.web.security.security.CookieTokenService;
+
+import io.meeds.web.security.storage.PortalTokenStorage;
+
+/**
+ * Persistent token service used by service workers to retrieve a web
+ * notification after the web session cookie has expired. The generated token is
+ * persisted through {@link PortalTokenStorage} by the parent
+ * {@link CookieTokenService}; only the token selector and salted hash are
+ * stored. The token type binds the token to both the notification and the push
+ * subscription, so the same raw token cannot be used for another notification
+ * or another device subscription. The service also exposes consumeToken(...)
+ * for single-push delivery tokens: after the first successful push fetch, the
+ * token is deleted from the persistent store.
+ */
+@Service
+public class PwaNotificationTokenService extends CookieTokenService {
+
+  public static final String TOKEN_TYPE_PREFIX = "pwa-notification";
+
+  public PwaNotificationTokenService(PortalTokenStorage tokenStore) {
+    super(initParams(), tokenStore);
+  }
+
+  public String createToken(String username, long notificationId, String subscriptionId) {
+    if (StringUtils.isBlank(username)) {
+      throw new IllegalArgumentException("username is mandatory");
+    }
+    if (StringUtils.isBlank(subscriptionId)) {
+      throw new IllegalArgumentException("subscriptionId is mandatory");
+    }
+    return super.createToken(username, buildTokenType(notificationId, subscriptionId));
+  }
+
+  public String validateToken(String token, long notificationId, String subscriptionId) {
+    return validateToken(token, notificationId, subscriptionId, false);
+  }
+
+  public String consumeToken(String token, long notificationId, String subscriptionId) {
+    return validateToken(token, notificationId, subscriptionId, true);
+  }
+
+  public String validateToken(String token, long notificationId, String subscriptionId, boolean remove) {
+    if (StringUtils.isBlank(token) || StringUtils.isBlank(subscriptionId)) {
+      return null;
+    }
+    String tokenType = buildTokenType(notificationId, subscriptionId);
+    PortalToken portalToken = remove ? super.deleteToken(token, tokenType) : super.getToken(token, tokenType);
+    if (portalToken == null) {
+      return null;
+    }
+    if (portalToken.getExpirationTimeMillis() > System.currentTimeMillis()) {
+      return portalToken.getUsername();
+    } else if (!remove) {
+      super.deleteToken(token, tokenType);
+    }
+    return null;
+  }
+
+  public void deleteNotificationToken(String token, long notificationId, String subscriptionId) {
+    if (StringUtils.isNotBlank(token) && StringUtils.isNotBlank(subscriptionId)) {
+      super.deleteToken(token, buildTokenType(notificationId, subscriptionId));
+    }
+  }
+
+  public void deleteNotificationTokens(String username) {
+    if (StringUtils.isNotBlank(username)) {
+      super.deleteTokensByUsernameAndType(username, TOKEN_TYPE_PREFIX);
+    }
+  }
+
+  protected String buildTokenType(long notificationId, String subscriptionId) {
+    return TOKEN_TYPE_PREFIX + ":" + scopeHash(notificationId, subscriptionId);
+  }
+
+  private static InitParams initParams() {
+    InitParams initParams = new InitParams();
+    ValuesParam valuesParam = new ValuesParam();
+    valuesParam.setName("service.configuration");
+    valuesParam.setValues(List.of(TOKEN_TYPE_PREFIX,
+                                  String.valueOf(TimeUnit.SECONDS.toHours(Long.parseLong(System.getProperty("pwa.notifications.push.token.ttl.seconds",
+                                                                                                            "28800")))),
+                                  "HOUR"));
+    initParams.addParam(valuesParam);
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("cleanup.period.time");
+    valueParam.setValue("3600");
+    initParams.addParam(valueParam);
+    return initParams;
+  }
+
+  private String scopeHash(long notificationId, String subscriptionId) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest((notificationId + ":" + subscriptionId).getBytes(StandardCharsets.UTF_8));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm is not available", e);
+    }
+  }
+}

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaSubscriptionService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaSubscriptionService.java
@@ -50,17 +50,36 @@ public class PwaSubscriptionService {
     return pwaSubscriptionStorage.get(username);
   }
 
+  public UserPushSubscription getSubscription(String username, String id) {
+    return getSubscriptions(username).stream()
+                                     .filter(s -> StringUtils.equals(s.getId(), id))
+                                     .findFirst()
+                                     .orElse(null);
+  }
+
   public void createSubscription(UserPushSubscription subscription,
                                  String username) {
     List<UserPushSubscription> subscriptions = pwaSubscriptionStorage.get(username);
     String endpoint = subscription.getEndpoint();
-    if (subscriptions.stream().noneMatch(s -> StringUtils.equals(s.getEndpoint(), endpoint))) {
+    UserPushSubscription existingSubscription = subscriptions.stream()
+                                                             .filter(s -> StringUtils.equals(s.getEndpoint(), endpoint))
+                                                             .findFirst()
+                                                             .orElse(null);
+    if (existingSubscription == null) {
       LOG.info("Create new subscription with id {} for user {} and endpoint {}",
                subscription.getId(),
                username,
                getSubscriptionDomain(endpoint));
       pwaSubscriptionStorage.create(subscription, username);
       listenerService.broadcast(PWA_INSTALLED, username, subscription);
+    } else if (!StringUtils.equals(existingSubscription.getPushDeviceSecret(), subscription.getPushDeviceSecret())
+               || !StringUtils.equals(existingSubscription.getId(), subscription.getId())) {
+      LOG.info("Update subscription with id {} for user {} and endpoint {}",
+               subscription.getId(),
+               username,
+               getSubscriptionDomain(endpoint));
+      pwaSubscriptionStorage.delete(existingSubscription.getId(), username);
+      pwaSubscriptionStorage.create(subscription, username);
     } else {
       LOG.debug("Subscription for endpoint {} already exists for user {}", getSubscriptionDomain(endpoint), username);
     }

--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -35,6 +35,11 @@ const offlineAssets = [
   `/pwa/i18n/locale.portlet.OfflineApplication`,
 ];
 
+const pushDeviceDbName = 'pwa-push-device';
+const pushDeviceStoreName = 'secrets';
+const pushDeviceSecretKeyPrefix = 'push-device-secret-';
+const pushAuthScheme = 'PWA-Notification';
+
 const checkCache = async () => {
   const version = await getCacheVersion();
   if (version !== getCacheVersionValue()) {
@@ -141,8 +146,10 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('activate', event => {
-  event.waitUntil(clients.claim());
-  activateNavigationPreload();
+  event.waitUntil(Promise.all([
+    clients.claim(),
+    activateNavigationPreload(),
+  ]));
 });
 
 if (offlineModeEnabled) {
@@ -151,28 +158,36 @@ if (offlineModeEnabled) {
   });
 }
 
+self.addEventListener('message', event => {
+  if (event?.data?.action === 'set-push-device-secret'
+      && event.data.subscriptionId
+      && event.data.pushDeviceSecret) {
+    event.waitUntil(setPushDeviceSecret(event.data.subscriptionId, event.data.pushDeviceSecret));
+  }
+});
+
 self.addEventListener('push', event => {
   if (self?.Notification?.permission === 'granted') {
     const data = event?.data?.text?.() || {};
     const params = data.split(':');
     const notificationType = params[0];
     if(!notificationType || notificationType === 'WEB_NOTIFICATION') {
-      const action = params[2]
+      const action = params[2];
       event.waitUntil(new Promise(async (resolve, reject) => {
         try {
           if (action === 'open') {
-            const notificationId = params[1]
-            const webNotification = await fetch(`/pwa/rest/notifications/${notificationId}`, {
-              method: 'GET',
-              credentials: 'include',
-            }).then(resp => resp.ok && resp.json());
-            if (webNotification) {
-              const title = webNotification.title || '';
-              webNotification.type = 'WEB_NOTIFICATION';
-              prepareNotificationToSend(notificationId, webNotification);
-              await self.registration.showNotification(title, webNotification);
-              await refreshBadge();
+            const notificationId = params[1];
+            const notificationAccessToken = params[3];
+            const subscriptionId = params[4];
+            const webNotification = await getWebNotification(notificationId, notificationAccessToken, subscriptionId);
+            if (!webNotification) {
+              webNotification = getFallbackNotification(notificationId);
             }
+            const title = webNotification.title || getFallbackNotificationTitle();
+            webNotification.type = 'WEB_NOTIFICATION';
+            prepareNotificationToSend(notificationId, webNotification, notificationAccessToken, subscriptionId);
+            await self.registration.showNotification(title, webNotification);
+            await refreshBadge();
           }
           resolve();
         } catch (e) {
@@ -189,10 +204,12 @@ self.addEventListener('notificationclick', event => {
   event.waitUntil(new Promise(async (resolve) => {
     event.notification.close();
     const notificationId = event?.notification?.data?.notificationId || event?.notification?.tag;
+    const notificationAccessToken = event?.notification?.data?.accessToken;
+    const subscriptionId = event?.notification?.data?.subscriptionId;
     try {
       if (event.action) {
         if(!notificationType || notificationType === 'WEB_NOTIFICATION') {
-          await updateNotification(notificationId, event.action);
+          await updateNotification(notificationId, event.action, notificationAccessToken, subscriptionId);
         }
       } else if (clients && 'openWindow' in clients && 'matchAll' in clients) {
         const windowClients = await clients.matchAll({
@@ -230,7 +247,7 @@ self.addEventListener('notificationclick', event => {
     } catch(e) {
       console.error(e);
     } finally {
-      await markAsRead(notificationId);
+      await markAsRead(notificationId, notificationAccessToken, subscriptionId);
       resolve();
     }
   }));
@@ -240,9 +257,9 @@ self.addEventListener('notificationclose', event => {
   event.waitUntil(refreshBadge);
 });
 
-async function markAsRead(notificationId) {
+async function markAsRead(notificationId, notificationAccessToken, subscriptionId) {
   try {
-    await updateNotification(notificationId, 'markRead');
+    await updateNotification(notificationId, 'markRead', notificationAccessToken, subscriptionId);
   } catch(e) {
     console.error(e);
   }
@@ -253,7 +270,22 @@ async function markAsRead(notificationId) {
   }
 }
 
-async function updateNotification(notificationId, action) {
+async function updateNotification(notificationId, action, notificationAccessToken, subscriptionId) {
+  const authorizationHeader = await getPushAuthorizationHeader(notificationId, notificationAccessToken, subscriptionId);
+  if (authorizationHeader) {
+    const response = await fetch(`/pwa/rest/notifications/${notificationId}/push`, {
+      method: 'PATCH',
+      credentials: 'omit',
+      headers: {
+        'Authorization': authorizationHeader,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `action=${action}`
+    });
+    if (response.ok) {
+      return;
+    }
+  }
   await fetch(`/pwa/rest/notifications/${notificationId}`, {
     method: 'PATCH',
     credentials: 'include',
@@ -261,6 +293,108 @@ async function updateNotification(notificationId, action) {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: `action=${action}`
+  });
+}
+
+async function getWebNotification(notificationId, notificationAccessToken, subscriptionId) {
+  const authorizationHeader = await getPushAuthorizationHeader(notificationId, notificationAccessToken, subscriptionId);
+  if (authorizationHeader) {
+    const response = await fetch(`/pwa/rest/notifications/${notificationId}/push`, {
+      method: 'GET',
+      credentials: 'omit',
+      headers: {
+        'Authorization': authorizationHeader,
+      },
+    });
+    if (response.ok) {
+      return response.json();
+    }
+  }
+  return fetch(`/pwa/rest/notifications/${notificationId}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => resp.ok && resp.json());
+}
+
+async function getPushAuthorizationHeader(notificationId, notificationAccessToken, subscriptionId) {
+  if (!notificationAccessToken || !subscriptionId) {
+    return null;
+  }
+  const deviceSecret = await getPushDeviceSecret(subscriptionId);
+  if (!deviceSecret) {
+    return null;
+  }
+  const timestamp = Date.now().toString();
+  const proof = await hmac(deviceSecret, `${notificationId}:${notificationAccessToken}:${subscriptionId}:${timestamp}`);
+  return `${pushAuthScheme} token=${notificationAccessToken},subscriptionId=${subscriptionId},timestamp=${timestamp},proof=${proof}`;
+}
+
+async function hmac(secret, payload) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    base64ToBytes(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+  return base64UrlEncode(new Uint8Array(signature));
+}
+
+function base64UrlEncode(bytes) {
+  let value = '';
+  bytes.forEach(byte => value += String.fromCharCode(byte));
+  return btoa(value)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function base64ToBytes(value) {
+  return Uint8Array.from(atob(value), c => c.charCodeAt(0));
+}
+
+async function getPushDeviceSecret(subscriptionId) {
+  return getPushDeviceStoreValue(`${pushDeviceSecretKeyPrefix}${subscriptionId}`);
+}
+
+async function setPushDeviceSecret(subscriptionId, secret) {
+  return setPushDeviceStoreValue(`${pushDeviceSecretKeyPrefix}${subscriptionId}`, secret);
+}
+
+async function openPushDeviceStore() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(pushDeviceDbName, 1);
+    request.onupgradeneeded = () => request.result.createObjectStore(pushDeviceStoreName);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function getPushDeviceStoreValue(key) {
+  const db = await openPushDeviceStore();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(pushDeviceStoreName, 'readonly');
+    const request = transaction.objectStore(pushDeviceStoreName).get(key);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    transaction.oncomplete = () => db.close();
+  });
+}
+
+async function setPushDeviceStoreValue(key, value) {
+  const db = await openPushDeviceStore();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(pushDeviceStoreName, 'readwrite');
+    transaction.objectStore(pushDeviceStoreName).put(value, key);
+    transaction.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    transaction.onerror = () => {
+      db.close();
+      reject(transaction.error);
+    };
   });
 }
 
@@ -275,7 +409,22 @@ async function refreshBadge() {
   }
 }
 
-function prepareNotificationToSend(notificationId, webNotification) {
+function getFallbackNotification(notificationId) {
+  return {
+    title: getFallbackNotificationTitle(),
+    body: 'Open the app to view this notification.',
+    url: '/',
+    tag: notificationId,
+    requireInteraction: true,
+    renotify: true,
+  };
+}
+
+function getFallbackNotificationTitle() {
+  return 'New notification';
+}
+
+function prepareNotificationToSend(notificationId, webNotification, notificationAccessToken, subscriptionId) {
   delete webNotification.title;
   webNotification.icon = webNotification.icon || webNotification.image || self.location.origin + '/pwa/rest/manifest/smallIcon?sizes=72x72';
   webNotification.badge = self.location.origin + '/pwa/rest/manifest/monochromeIcon';
@@ -284,6 +433,8 @@ function prepareNotificationToSend(notificationId, webNotification) {
     notificationId,
     url: self.location.origin + (webNotification.url || '/'),
     type: webNotification.type,
+    accessToken: notificationAccessToken,
+    subscriptionId,
   };
   delete webNotification.url;
   if (!webNotification.tag) {

--- a/pwa-service/src/test/java/io/meeds/pwa/listener/WebNotificationSentListenerTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/listener/WebNotificationSentListenerTest.java
@@ -18,9 +18,6 @@
  */
 package io.meeds.pwa.listener;
 
-import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_DELETED_EVENT;
-import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_READ_ALL_EVENT;
-import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_READ_EVENT;
 import static org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage.NOTIFICATION_WEB_SAVED_EVENT;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,7 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.ListenerService;
@@ -43,17 +40,17 @@ import org.exoplatform.services.listener.ListenerService;
 import io.meeds.pwa.service.PwaNotificationService;
 
 @SpringBootTest(classes = {
-                            WebNotificationSentListener.class,
+  WebNotificationSentListener.class,
 })
 @ExtendWith(MockitoExtension.class)
 public class WebNotificationSentListenerTest {
 
   private static final String         NOTIFICATION_ID = "5";
 
-  @MockBean
+  @MockitoBean
   private PwaNotificationService      pwaNotificationService;
 
-  @MockBean
+  @MockitoBean
   private ListenerService             listenerService;
 
   @Autowired

--- a/pwa-service/src/test/java/io/meeds/pwa/rest/PwaNotificationRestTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/rest/PwaNotificationRestTest.java
@@ -38,11 +38,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -94,7 +94,7 @@ public class PwaNotificationRestTest {
     OBJECT_MAPPER.registerModule(new JavaTimeModule());
   }
 
-  @MockBean
+  @MockitoBean
   private PwaNotificationService pwaNotificationService;
 
   @Autowired

--- a/pwa-service/src/test/java/io/meeds/pwa/rest/PwaPushSubscriptionRestTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/rest/PwaPushSubscriptionRestTest.java
@@ -33,11 +33,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -83,7 +83,7 @@ public class PwaPushSubscriptionRestTest {
     OBJECT_MAPPER.registerModule(new JavaTimeModule());
   }
 
-  @MockBean
+  @MockitoBean
   private PwaSubscriptionService pwaSubscriptionService;
 
   @Autowired

--- a/pwa-service/src/test/java/io/meeds/pwa/rest/ServiceWorkerRestTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/rest/ServiceWorkerRestTest.java
@@ -13,9 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -54,7 +54,7 @@ public class ServiceWorkerRestTest {
     OBJECT_MAPPER.registerModule(new JavaTimeModule());
   }
 
-  @MockBean
+  @MockitoBean
   private PwaSwService          pwaSwService;
 
   @Autowired

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaManifestServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaManifestServiceTest.java
@@ -59,9 +59,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.repository.init.ResourceReader;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.exoplatform.commons.api.notification.channel.AbstractChannel;
 import org.exoplatform.commons.api.notification.channel.ChannelManager;
@@ -92,17 +92,22 @@ import io.meeds.pwa.model.PwaManifest;
 import io.meeds.pwa.model.PwaManifestUpdate;
 
 @SpringBootTest(classes = {
-                            PwaManifestService.class,
+  PwaManifestService.class,
 })
-@TestPropertySource(
-                    properties = {
-                                   "pwa.manifest.id=manifestId",
-                                   "pwa.manifest.version=V4",
-                                   "pwa.manifest.description=manifestDescriptionKey",
-                                   "pwa.manifest.path=pwaManifestPath",
-                    })
+@TestPropertySource(properties = {
+  "pwa.manifest.id=manifestId",
+  "pwa.manifest.version=V4",
+  "pwa.manifest.description=manifestDescriptionKey",
+  "pwa.manifest.path=pwaManifestPath",
+})
 @ExtendWith(MockitoExtension.class)
 public class PwaManifestServiceTest {
+
+  private static final String   TEST_ICON_PNG            = "test_icon.png";
+
+  private static final String   THEME_COLOR_OTHER        = "themeColor2";
+
+  private static final String   BACKGROUND_COLOR_OTHER   = "backgroundColor2";
 
   private static final Random   RANDOM                   = new Random();
 
@@ -130,37 +135,37 @@ public class PwaManifestServiceTest {
 
   private static final String   PWA_MANIFEST_PATH        = "pwaManifestPath";
 
-  @MockBean
+  @MockitoBean
   private SettingService        settingService;
 
-  @MockBean
+  @MockitoBean
   private FileService           fileService;
 
-  @MockBean
+  @MockitoBean
   private UploadService         uploadService;
 
-  @MockBean
+  @MockitoBean
   private BrandingService       brandingService;
 
-  @MockBean
+  @MockitoBean
   private ConfigurationManager  configurationManager;
 
-  @MockBean
+  @MockitoBean
   private ExoFeatureService     featureService;
 
-  @MockBean
+  @MockitoBean
   private ResourceBundleService resourceBundleService;
 
-  @MockBean
+  @MockitoBean
   private ImageThumbnailService imageThumbnailService;
 
-  @MockBean
+  @MockitoBean
   private ImageResizeService    imageResizeService;
 
-  @MockBean
+  @MockitoBean
   private ChannelManager        channelManager;
 
-  @MockBean
+  @MockitoBean
   private ListenerService       listenerService;
 
   @Autowired
@@ -278,7 +283,8 @@ public class PwaManifestServiceTest {
 
     long manifestHash = pwaManifestService.getManifestHash();
     assertNotEquals(0l, manifestHash);
-    assertEquals(manifestHash, pwaManifestService.getManifestHash()); // No change
+    assertEquals(manifestHash, pwaManifestService.getManifestHash()); // No
+                                                                      // change
 
     mockWithStoredValues();
     pwaManifestService.refreshManifest();
@@ -306,7 +312,6 @@ public class PwaManifestServiceTest {
 
     pwaManifestService.init();
 
-
     PwaManifestUpdate manifestUpdate = new PwaManifestUpdate();
     manifestUpdate.setEnabled(true);
     manifestUpdate.setName("Name2");
@@ -314,17 +319,17 @@ public class PwaManifestServiceTest {
     manifestUpdate.setLargeIconUploadId("largeIconUploadId");
     manifestUpdate.setSmallIconUploadId("smallIconUploadId");
 
-    manifestUpdate.setThemeColor("themeColor2");
+    manifestUpdate.setThemeColor(THEME_COLOR_OTHER);
     manifestUpdate.setBackgroundColor("eval");
 
     assertThrows(IllegalArgumentException.class, () -> pwaManifestService.updateManifest(manifestUpdate, TEST_USER));
 
     manifestUpdate.setThemeColor("eval");
-    manifestUpdate.setBackgroundColor("backgroundColor2");
+    manifestUpdate.setBackgroundColor(BACKGROUND_COLOR_OTHER);
     assertThrows(IllegalArgumentException.class, () -> pwaManifestService.updateManifest(manifestUpdate, TEST_USER));
 
-    manifestUpdate.setThemeColor("themeColor2");
-    manifestUpdate.setBackgroundColor("backgroundColor2");
+    manifestUpdate.setThemeColor(THEME_COLOR_OTHER);
+    manifestUpdate.setBackgroundColor(BACKGROUND_COLOR_OTHER);
     assertThrows(IllegalArgumentException.class, () -> pwaManifestService.updateManifest(manifestUpdate, TEST_USER));
 
     when(fileService.writeFile(any())).thenAnswer(invocation -> {
@@ -335,22 +340,19 @@ public class PwaManifestServiceTest {
       return fileItem;
     });
 
-
     UploadResource largeIconUploadResource = mock(UploadResource.class);
     when(uploadService.getUploadResource(manifestUpdate.getLargeIconUploadId())).thenReturn(largeIconUploadResource);
     when(largeIconUploadResource.getStoreLocation()).thenReturn(getClass().getClassLoader()
-                                                                          .getResource("test_icon.png")
+                                                                          .getResource(TEST_ICON_PNG)
                                                                           .getPath());
     UploadResource smallIconUploadResource = mock(UploadResource.class);
     when(uploadService.getUploadResource(manifestUpdate.getSmallIconUploadId())).thenReturn(smallIconUploadResource);
     when(smallIconUploadResource.getStoreLocation()).thenReturn(getClass().getClassLoader()
-                                                                          .getResource("test_icon.png")
+                                                                          .getResource(TEST_ICON_PNG)
                                                                           .getPath());
 
-
-    InputStream is = ResourceReader.class
-        .getClassLoader()
-        .getResourceAsStream("test_icon.png");
+    InputStream is = ResourceReader.class.getClassLoader()
+                                         .getResourceAsStream(TEST_ICON_PNG);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -367,13 +369,11 @@ public class PwaManifestServiceTest {
 
     byte[] data = baos.toByteArray();
 
-
     FileInfo fileInfo = mock(FileInfo.class);
     when(fileInfo.getUpdatedDate()).thenReturn(new Date(System.currentTimeMillis()));
     when(fileInfo.getSize()).thenReturn(Long.valueOf(data.length));
     FileItem monoChromeIconFileItem = new FileItem(fileInfo, new ByteArrayInputStream(data));
     when(fileService.getFile(anyLong())).thenReturn(monoChromeIconFileItem);
-
 
     pwaManifestService.updateManifest(manifestUpdate, TEST_USER);
 
@@ -458,17 +458,17 @@ public class PwaManifestServiceTest {
     manifestUpdate.setLargeIconUploadId("largeIconUploadId");
     manifestUpdate.setSmallIconUploadId("smallIconUploadId");
 
-    manifestUpdate.setThemeColor("themeColor2");
+    manifestUpdate.setThemeColor(THEME_COLOR_OTHER);
     manifestUpdate.setBackgroundColor("eval");
 
     assertThrows(IllegalArgumentException.class, () -> pwaManifestService.updateManifest(manifestUpdate, TEST_USER));
 
     manifestUpdate.setThemeColor("eval");
-    manifestUpdate.setBackgroundColor("backgroundColor2");
+    manifestUpdate.setBackgroundColor(BACKGROUND_COLOR_OTHER);
     assertThrows(IllegalArgumentException.class, () -> pwaManifestService.updateManifest(manifestUpdate, TEST_USER));
 
-    manifestUpdate.setThemeColor("themeColor2");
-    manifestUpdate.setBackgroundColor("backgroundColor2");
+    manifestUpdate.setThemeColor(THEME_COLOR_OTHER);
+    manifestUpdate.setBackgroundColor(BACKGROUND_COLOR_OTHER);
     assertThrows(IllegalArgumentException.class, () -> pwaManifestService.updateManifest(manifestUpdate, TEST_USER));
 
     when(fileService.writeFile(any())).thenAnswer(invocation -> {
@@ -482,12 +482,12 @@ public class PwaManifestServiceTest {
     UploadResource largeIconUploadResource = mock(UploadResource.class);
     when(uploadService.getUploadResource(manifestUpdate.getLargeIconUploadId())).thenReturn(largeIconUploadResource);
     when(largeIconUploadResource.getStoreLocation()).thenReturn(getClass().getClassLoader()
-                                                                          .getResource("test_icon.png")
+                                                                          .getResource(TEST_ICON_PNG)
                                                                           .getPath());
     UploadResource smallIconUploadResource = mock(UploadResource.class);
     when(uploadService.getUploadResource(manifestUpdate.getSmallIconUploadId())).thenReturn(smallIconUploadResource);
     when(smallIconUploadResource.getStoreLocation()).thenReturn(getClass().getClassLoader()
-                                                                          .getResource("test_icon.png")
+                                                                          .getResource(TEST_ICON_PNG)
                                                                           .getPath());
     pwaManifestService.updateManifest(manifestUpdate, TEST_USER);
     assertTrue(pwaManifestService.isPwaEnabled());

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
@@ -18,7 +18,12 @@
  */
 package io.meeds.pwa.service;
 
-import static io.meeds.pwa.service.PwaNotificationService.*;
+import static io.meeds.pwa.service.PwaNotificationService.EVENT_ACTION_PARAM_NAME;
+import static io.meeds.pwa.service.PwaNotificationService.EVENT_NOTIFICATION_ID_PARAM_NAME;
+import static io.meeds.pwa.service.PwaNotificationService.EVENT_USERNAME_PARAM_NAME;
+import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_MARK_READ_USER_ACTION;
+import static io.meeds.pwa.service.PwaNotificationService.PWA_NOTIFICATION_OPEN_UI_ACTION;
+import static io.meeds.pwa.service.PwaNotificationService.WEB_NOTIFICATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,24 +31,31 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.model.PluginKey;
@@ -65,10 +77,11 @@ import io.meeds.pwa.plugin.DefaultPwaNotificationPlugin;
 import io.meeds.pwa.storage.PwaNotificationStorage;
 
 import lombok.SneakyThrows;
+import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
 
 @SpringBootTest(classes = {
-                            PwaNotificationService.class,
+  PwaNotificationService.class,
 })
 public class PwaNotificationServiceTest {
 
@@ -76,41 +89,51 @@ public class PwaNotificationServiceTest {
 
   private static final String          SUBSCRIPTION_ENDPOINT = "http://localhost/endpoint";
 
+  private static final String          PUSH_AUTH_SCHEME      = "PWA-Notification";
+
+  private static final String          PUSH_DEVICE_SECRET    = Base64.getEncoder()
+                                                                     .encodeToString("testPushDeviceSecret".getBytes(StandardCharsets.UTF_8));
+
+  private static final String          PUSH_ACCESS_TOKEN     = "generatedPushAccessTokenWithEnoughLength";
+
   private static final PluginKey       PLUGIN_KEY            = PluginKey.key("TestPlugin");
 
   private static final long            NOTIFICATION_ID       = 12l;
 
   private static final String          TEST_USER             = "testUser";
 
-  @MockBean
+  @MockitoBean
   private PwaManifestService           pwaManifestService;
 
-  @MockBean
+  @MockitoBean
   private PwaSubscriptionService       pwaSubscriptionService;
 
-  @MockBean
+  @MockitoBean
   private PwaNotificationStorage       pwaNotificationStorage;
 
-  @MockBean
+  @MockitoBean
   private WebNotificationService       webNotificationService;
 
-  @MockBean
+  @MockitoBean
   private ListenerService              listenerService;
 
-  @MockBean
+  @MockitoBean
   private OrganizationService          organizationService;
 
-  @MockBean
+  @MockitoBean
   private LocaleConfigService          localeConfigService;
 
-  @MockBean
+  @MockitoBean
   private ResourceBundleService        resourceBundleService;
 
-  @MockBean
+  @MockitoBean
   private DefaultPwaNotificationPlugin defaultPwaNotificationPlugin;
 
-  @MockBean
+  @MockitoBean
   private PushService                  pushService;
+
+  @MockitoBean
+  private PwaNotificationTokenService  pwaNotificationTokenService;
 
   @Autowired
   private PwaNotificationService       pwaNotificationService;
@@ -159,6 +182,66 @@ public class PwaNotificationServiceTest {
   }
 
   @Test
+  public void getNotificationFromPush() throws Exception { // NOSONAR
+    String[] payloadParts = createPushNotificationAndGetPayloadParts(true);
+    String token = payloadParts[3];
+    when(pwaNotificationTokenService.validateToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(TEST_USER);
+    when(pwaNotificationTokenService.consumeToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(TEST_USER);
+    String authorizationHeader = buildAuthorizationHeader(token, SUBSCRIPTION_ID, System.currentTimeMillis());
+    mockUserLanguage();
+    when(pwaSubscriptionService.getSubscription(TEST_USER, SUBSCRIPTION_ID)).thenReturn(userPushSubscription);
+    when(defaultPwaNotificationPlugin.process(eq(notification), any())).thenReturn(notificationMessage);
+
+    PwaNotificationMessage result = pwaNotificationService.getNotificationFromPush(NOTIFICATION_ID, authorizationHeader);
+
+    assertEquals(notificationMessage, result);
+    verify(defaultPwaNotificationPlugin).process(eq(notification), any());
+  }
+
+  @Test
+  public void getNotificationFromPushWhenInvalidAuthorization() throws Exception { // NOSONAR
+    assertThrows(IllegalAccessException.class, () -> pwaNotificationService.getNotificationFromPush(NOTIFICATION_ID, null));
+    assertThrows(IllegalAccessException.class,
+                 () -> pwaNotificationService.getNotificationFromPush(NOTIFICATION_ID,
+                                                                      PUSH_AUTH_SCHEME + " token=\"unknown\""));
+
+    String[] payloadParts = createPushNotificationAndGetPayloadParts(true);
+    String token = payloadParts[3];
+    long timestamp = System.currentTimeMillis();
+    when(pwaNotificationTokenService.validateToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(TEST_USER);
+    when(pwaNotificationTokenService.consumeToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(TEST_USER);
+    when(pwaSubscriptionService.getSubscription(TEST_USER, SUBSCRIPTION_ID)).thenReturn(userPushSubscription);
+
+    assertThrows(IllegalAccessException.class,
+                 () -> pwaNotificationService.getNotificationFromPush(NOTIFICATION_ID,
+                                                                      buildAuthorizationHeader(token,
+                                                                                               SUBSCRIPTION_ID,
+                                                                                               timestamp,
+                                                                                               "invalidProof")));
+    assertThrows(IllegalAccessException.class,
+                 () -> pwaNotificationService.getNotificationFromPush(NOTIFICATION_ID + 1,
+                                                                      buildAuthorizationHeader(token,
+                                                                                               SUBSCRIPTION_ID,
+                                                                                               timestamp)));
+  }
+
+  @Test
+  public void updateNotificationFromPush() throws Exception { // NOSONAR
+    String[] payloadParts = createPushNotificationAndGetPayloadParts(true);
+    String token = payloadParts[3];
+    when(pwaNotificationTokenService.validateToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(TEST_USER);
+    when(pwaNotificationTokenService.consumeToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(TEST_USER);
+    String authorizationHeader = buildAuthorizationHeader(token, SUBSCRIPTION_ID, System.currentTimeMillis());
+    when(pwaSubscriptionService.getSubscription(TEST_USER, SUBSCRIPTION_ID)).thenReturn(userPushSubscription);
+
+    pwaNotificationService.updateNotificationFromPush(NOTIFICATION_ID,
+                                                      PWA_NOTIFICATION_MARK_READ_USER_ACTION,
+                                                      authorizationHeader);
+
+    verify(webNotificationService).markRead(String.valueOf(NOTIFICATION_ID));
+  }
+
+  @Test
   public void updateNotification() throws IllegalAccessException, ObjectNotFoundException {
     assertThrows(ObjectNotFoundException.class,
                  () -> pwaNotificationService.updateNotification(NOTIFICATION_ID,
@@ -190,9 +273,7 @@ public class PwaNotificationServiceTest {
     verifyNoInteractions(listenerService);
 
     mockWebNotification();
-    when(pwaSubscriptionService.getSubscriptions(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
-    when(userPushSubscription.getEndpoint()).thenReturn(SUBSCRIPTION_ENDPOINT);
-    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
+    mockSubscription(false);
     when(pushService.send(any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(401);
@@ -201,8 +282,8 @@ public class PwaNotificationServiceTest {
     assertNotNull(future);
     assertEquals(0, (int) future.get());
     verify(pwaSubscriptionService, never()).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
-    verify(pushService).send(argThat(n -> ("WEB_NOTIFICATION" + ":" + NOTIFICATION_ID + ":" +
-        PWA_NOTIFICATION_OPEN_UI_ACTION).equals(new String(n.getPayload()))));
+    verify(pushService).send(argThat(n -> (WEB_NOTIFICATION + ":" + NOTIFICATION_ID + ":" +
+        PWA_NOTIFICATION_OPEN_UI_ACTION).equals(new String(n.getPayload(), StandardCharsets.UTF_8))));
 
     when(statusLine.getStatusCode()).thenReturn(410);
     future = pwaNotificationService.create(NOTIFICATION_ID);
@@ -215,6 +296,28 @@ public class PwaNotificationServiceTest {
     assertNotNull(future);
     assertEquals(1, (int) future.get());
     verify(pwaSubscriptionService).deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
+  }
+
+  @Test
+  public void createWhenSubscriptionHasDeviceSecretAddsPushAccessToken() throws Exception { // NOSONAR
+    String[] payloadParts = createPushNotificationAndGetPayloadParts(true);
+
+    assertEquals(5, payloadParts.length);
+    assertEquals(WEB_NOTIFICATION, payloadParts[0]);
+    assertEquals(String.valueOf(NOTIFICATION_ID), payloadParts[1]);
+    assertEquals(PWA_NOTIFICATION_OPEN_UI_ACTION, payloadParts[2]);
+    assertEquals(PUSH_ACCESS_TOKEN, payloadParts[3]);
+    assertEquals(SUBSCRIPTION_ID, payloadParts[4]);
+  }
+
+  @Test
+  public void createWhenSubscriptionHasNoDeviceSecretKeepsLegacyPayload() throws Exception { // NOSONAR
+    String[] payloadParts = createPushNotificationAndGetPayloadParts(false);
+
+    assertEquals(3, payloadParts.length);
+    assertEquals(WEB_NOTIFICATION, payloadParts[0]);
+    assertEquals(String.valueOf(NOTIFICATION_ID), payloadParts[1]);
+    assertEquals(PWA_NOTIFICATION_OPEN_UI_ACTION, payloadParts[2]);
   }
 
   @Test
@@ -233,6 +336,50 @@ public class PwaNotificationServiceTest {
     verifyNoInteractions(listenerService);
   }
 
+  private String[] createPushNotificationAndGetPayloadParts(boolean withDeviceSecret) throws Exception { // NOSONAR
+    when(pwaManifestService.isPwaEnabled()).thenReturn(true);
+    mockWebNotification();
+    mockSubscription(withDeviceSecret);
+    if (withDeviceSecret) {
+      when(pwaNotificationTokenService.createToken(TEST_USER, NOTIFICATION_ID, SUBSCRIPTION_ID)).thenReturn(PUSH_ACCESS_TOKEN);
+    }
+    when(pushService.send(any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+
+    ScheduledFuture<?> future = pwaNotificationService.create(NOTIFICATION_ID);
+
+    assertNotNull(future);
+    assertEquals(1, (int) future.get());
+    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+    verify(pushService).send(notificationCaptor.capture());
+    return new String(notificationCaptor.getValue().getPayload(), StandardCharsets.UTF_8).split(":");
+  }
+
+  private void mockSubscription(boolean withDeviceSecret) throws Exception { // NOSONAR
+    when(pwaSubscriptionService.getSubscriptions(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
+    lenient().when(pwaSubscriptionService.getSubscription(TEST_USER, SUBSCRIPTION_ID)).thenReturn(userPushSubscription);
+    when(userPushSubscription.getEndpoint()).thenReturn(SUBSCRIPTION_ENDPOINT);
+    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
+    when(userPushSubscription.getPushDeviceSecret()).thenReturn(withDeviceSecret ? PUSH_DEVICE_SECRET : null);
+  }
+
+  private String buildAuthorizationHeader(String token, String subscriptionId, long timestamp) throws Exception { // NOSONAR
+    return buildAuthorizationHeader(token, subscriptionId, timestamp, computeHmac(token, subscriptionId, timestamp));
+  }
+
+  private String buildAuthorizationHeader(String token, String subscriptionId, long timestamp, String proof) {
+    return PUSH_AUTH_SCHEME + " token=\"" + token + "\"," + "subscriptionId=\"" + subscriptionId + "\"," + "timestamp=\"" +
+        timestamp + "\"," + "proof=\"" + proof + "\"";
+  }
+
+  private String computeHmac(String token, String subscriptionId, long timestamp) throws Exception { // NOSONAR
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(new SecretKeySpec(Base64.getDecoder().decode(PUSH_DEVICE_SECRET), "HmacSHA256"));
+    String value = NOTIFICATION_ID + ":" + token + ":" + subscriptionId + ":" + timestamp;
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+  }
+
   @SneakyThrows
   private void mockUserLanguage() {
     when(organizationService.getUserProfileHandler()).thenReturn(userProfileHandler);
@@ -248,6 +395,7 @@ public class PwaNotificationServiceTest {
     when(webNotificationService.getNotificationInfo(String.valueOf(NOTIFICATION_ID))).thenReturn(notification);
     when(notification.getTo()).thenReturn(TEST_USER);
     when(notification.getId()).thenReturn(String.valueOf(NOTIFICATION_ID));
+    when(notification.getKey()).thenReturn(PLUGIN_KEY);
   }
 
   private void mockWebNotificationNoAccess() {

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationTokenServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationTokenServiceTest.java
@@ -1,0 +1,257 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.pwa.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.exoplatform.web.security.hash.SaltedHashService;
+import org.exoplatform.web.security.security.CookieTokenService;
+
+import io.meeds.web.security.model.TokenData;
+import io.meeds.web.security.storage.PortalTokenStorage;
+
+import lombok.SneakyThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class PwaNotificationTokenServiceTest {
+
+  private static final String TOKEN_VALUE                      = "token";
+
+  private static final String PWA_NOTIFICATIONS_PUSH_TOKEN_TTL = "pwa.notifications.push.token.ttl.seconds";
+
+  private static final String TEST_USER                        = "testUser";
+
+  private static final long   NOTIFICATION_ID                  = 123L;
+
+  private static final String SUBSCRIPTION_ID                  = "subscriptionId";
+
+  private static final String TOKEN_SELECTOR                   = "selector";
+
+  private static final String TOKEN_VALIDATOR                  = "validator";
+
+  @Mock
+  private PortalTokenStorage  tokenStore;
+
+  @Mock
+  private SaltedHashService   saltedHashService;
+
+  private String              previousTtl;
+
+  private TestTokenService    tokenService;
+
+  @BeforeEach
+  @SneakyThrows
+  public void setUp() {
+    previousTtl = System.getProperty(PWA_NOTIFICATIONS_PUSH_TOKEN_TTL);
+    System.setProperty(PWA_NOTIFICATIONS_PUSH_TOKEN_TTL, "3600");
+    tokenService = new TestTokenService(tokenStore);
+    ReflectionTestUtils.setField(tokenService, "saltedHashService", saltedHashService);
+    lenient().when(saltedHashService.getSaltedHash(any()))
+             .thenAnswer(invocation -> "hash:" + invocation.getArgument(0));
+    lenient().when(saltedHashService.validate(any(), any()))
+             .thenAnswer(invocation -> {
+               String tokenRandomString = invocation.getArgument(0);
+               String hash = invocation.getArgument(1);
+               return ("hash:" + tokenRandomString).equals(hash);
+             });
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (previousTtl == null) {
+      System.clearProperty(PWA_NOTIFICATIONS_PUSH_TOKEN_TTL);
+    } else {
+      System.setProperty(PWA_NOTIFICATIONS_PUSH_TOKEN_TTL, previousTtl);
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void createToken() {
+    String token = tokenService.createToken(TEST_USER, NOTIFICATION_ID, SUBSCRIPTION_ID);
+
+    assertEquals(TOKEN_SELECTOR + CookieTokenService.SEPARATOR_CHAR + TOKEN_VALIDATOR, token);
+
+    ArgumentCaptor<TokenData> tokenDataCaptor = ArgumentCaptor.forClass(TokenData.class);
+    verify(tokenStore).createToken(tokenDataCaptor.capture());
+
+    TokenData tokenData = tokenDataCaptor.getValue();
+    assertEquals(TOKEN_SELECTOR, tokenData.getTokenId());
+    assertEquals(TEST_USER, tokenData.getUsername());
+    assertEquals(tokenService.buildTokenType(NOTIFICATION_ID, SUBSCRIPTION_ID), tokenData.getTokenType());
+    assertNotNull(tokenData.getHash());
+    assertTrue(tokenData.getExpirationTime().getTime() > System.currentTimeMillis());
+  }
+
+  @Test
+  public void createTokenWhenMandatoryParametersAreMissing() {
+    assertThrows(IllegalArgumentException.class, () -> tokenService.createToken(null, NOTIFICATION_ID, SUBSCRIPTION_ID));
+    assertThrows(IllegalArgumentException.class, () -> tokenService.createToken("", NOTIFICATION_ID, SUBSCRIPTION_ID));
+    assertThrows(IllegalArgumentException.class, () -> tokenService.createToken(TEST_USER, NOTIFICATION_ID, null));
+    assertThrows(IllegalArgumentException.class, () -> tokenService.createToken(TEST_USER, NOTIFICATION_ID, ""));
+  }
+
+  @Test
+  public void validateToken() {
+    String token = createTokenAndMockLookup();
+
+    assertEquals(TEST_USER, tokenService.validateToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID));
+    verify(tokenStore, never()).deleteToken(TOKEN_SELECTOR);
+  }
+
+  @Test
+  public void validateTokenWhenTokenOrSubscriptionIsBlank() {
+    assertNull(tokenService.validateToken(null, NOTIFICATION_ID, SUBSCRIPTION_ID));
+    assertNull(tokenService.validateToken("", NOTIFICATION_ID, SUBSCRIPTION_ID));
+    assertNull(tokenService.validateToken(TOKEN_VALUE, NOTIFICATION_ID, null));
+    assertNull(tokenService.validateToken(TOKEN_VALUE, NOTIFICATION_ID, ""));
+  }
+
+  @Test
+  public void validateTokenWhenScopeDoesNotMatch() {
+    String token = createTokenAndMockLookup();
+
+    assertNull(tokenService.validateToken(token, NOTIFICATION_ID + 1, SUBSCRIPTION_ID));
+    assertNull(tokenService.validateToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID + "2"));
+  }
+
+  @Test
+  public void validateTokenWhenTokenIsExpired() {
+    String token = tokenService.createToken(TEST_USER, NOTIFICATION_ID, SUBSCRIPTION_ID);
+    TokenData tokenData = captureCreatedToken();
+    TokenData expiredTokenData = new TokenData(TOKEN_SELECTOR,
+                                               tokenData.getHash(),
+                                               TEST_USER,
+                                               new Date(System.currentTimeMillis() - 1000),
+                                               tokenService.buildTokenType(NOTIFICATION_ID, SUBSCRIPTION_ID));
+    when(tokenStore.getToken(TOKEN_SELECTOR)).thenReturn(expiredTokenData);
+
+    assertNull(tokenService.validateToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID));
+    verify(tokenStore).deleteToken(TOKEN_SELECTOR);
+  }
+
+  @Test
+  public void consumeToken() {
+    String token = createTokenAndMockLookup();
+
+    assertEquals(TEST_USER, tokenService.consumeToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID));
+    verify(tokenStore).deleteToken(TOKEN_SELECTOR);
+  }
+
+  @Test
+  public void consumeTokenWhenScopeDoesNotMatch() {
+    String token = createTokenAndMockLookup();
+
+    assertNull(tokenService.consumeToken(token, NOTIFICATION_ID + 1, SUBSCRIPTION_ID));
+    verify(tokenStore, never()).deleteToken(TOKEN_SELECTOR);
+  }
+
+  @Test
+  public void deleteNotificationToken() {
+    String token = createTokenAndMockLookup();
+
+    tokenService.deleteNotificationToken(token, NOTIFICATION_ID, SUBSCRIPTION_ID);
+
+    verify(tokenStore).deleteToken(TOKEN_SELECTOR);
+  }
+
+  @Test
+  public void deleteNotificationTokenWhenParametersAreBlank() {
+    tokenService.deleteNotificationToken(null, NOTIFICATION_ID, SUBSCRIPTION_ID);
+    tokenService.deleteNotificationToken("", NOTIFICATION_ID, SUBSCRIPTION_ID);
+    tokenService.deleteNotificationToken(TOKEN_VALUE, NOTIFICATION_ID, null);
+    tokenService.deleteNotificationToken(TOKEN_VALUE, NOTIFICATION_ID, "");
+
+    verify(tokenStore, never()).deleteToken(any());
+  }
+
+  @Test
+  public void deleteNotificationTokens() {
+    tokenService.deleteNotificationTokens(TEST_USER);
+
+    verify(tokenStore).deleteTokensByUsernameAndType(TEST_USER, PwaNotificationTokenService.TOKEN_TYPE_PREFIX);
+  }
+
+  @Test
+  public void deleteNotificationTokensWhenUsernameIsBlank() {
+    tokenService.deleteNotificationTokens(null);
+    tokenService.deleteNotificationTokens("");
+
+    verify(tokenStore, never()).deleteTokensByUsernameAndType(any(), any());
+  }
+
+  @Test
+  public void buildTokenType() {
+    String tokenType = tokenService.buildTokenType(NOTIFICATION_ID, SUBSCRIPTION_ID);
+
+    assertTrue(tokenType.startsWith(PwaNotificationTokenService.TOKEN_TYPE_PREFIX + ":"));
+    assertNotEquals(tokenType, tokenService.buildTokenType(NOTIFICATION_ID + 1, SUBSCRIPTION_ID));
+    assertNotEquals(tokenType, tokenService.buildTokenType(NOTIFICATION_ID, SUBSCRIPTION_ID + "2"));
+  }
+
+  private String createTokenAndMockLookup() {
+    String token = tokenService.createToken(TEST_USER, NOTIFICATION_ID, SUBSCRIPTION_ID);
+    TokenData tokenData = captureCreatedToken();
+    when(tokenStore.getToken(TOKEN_SELECTOR)).thenReturn(tokenData);
+    return token;
+  }
+
+  @SneakyThrows
+  private TokenData captureCreatedToken() {
+    ArgumentCaptor<TokenData> tokenDataCaptor = ArgumentCaptor.forClass(TokenData.class);
+    verify(tokenStore).createToken(tokenDataCaptor.capture());
+    return tokenDataCaptor.getValue();
+  }
+
+  private static class TestTokenService extends PwaNotificationTokenService {
+
+    private final AtomicInteger index = new AtomicInteger();
+
+    private TestTokenService(PortalTokenStorage tokenStore) {
+      super(tokenStore);
+    }
+
+    @Override
+    protected String nextRandom() {
+      return index.getAndIncrement() % 2 == 0 ? TOKEN_SELECTOR : TOKEN_VALIDATOR;
+    }
+  }
+}

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaSubscriptionServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaSubscriptionServiceTest.java
@@ -20,9 +20,12 @@ package io.meeds.pwa.service;
 
 import static io.meeds.pwa.service.PwaSubscriptionService.PWA_INSTALLED;
 import static io.meeds.pwa.service.PwaSubscriptionService.PWA_UNINSTALLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -32,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.exoplatform.services.listener.ListenerService;
 
@@ -40,7 +43,7 @@ import io.meeds.pwa.model.UserPushSubscription;
 import io.meeds.pwa.storage.PwaSubscriptionStorage;
 
 @SpringBootTest(classes = {
-                            PwaSubscriptionService.class,
+  PwaSubscriptionService.class,
 })
 public class PwaSubscriptionServiceTest {
 
@@ -48,12 +51,16 @@ public class PwaSubscriptionServiceTest {
 
   private static final String    SUBSCRIPTION_ENDPOINT = "http://localhost/endpoint";
 
+  private static final String    PUSH_DEVICE_SECRET    = "deviceSecret";
+
+  private static final String    NEW_SUBSCRIPTION_ID   = "newSubscriptionId";
+
   private static final String    TEST_USER             = "testUser";
 
-  @MockBean
+  @MockitoBean
   private PwaSubscriptionStorage pwaSubscriptionStorage;
 
-  @MockBean
+  @MockitoBean
   private ListenerService        listenerService;
 
   @Autowired
@@ -96,6 +103,65 @@ public class PwaSubscriptionServiceTest {
     when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
     pwaSubscriptionService.deleteAllSubscriptions(TEST_USER);
     verify(pwaSubscriptionStorage).delete(SUBSCRIPTION_ID, TEST_USER);
+  }
+
+
+  @Test
+  public void getSubscriptionShouldReturnMatchingSubscription() {
+    when(pwaSubscriptionStorage.get(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
+    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
+
+    UserPushSubscription result = pwaSubscriptionService.getSubscription(TEST_USER, SUBSCRIPTION_ID);
+
+    assertEquals(userPushSubscription, result);
+    assertNull(pwaSubscriptionService.getSubscription(TEST_USER, "unknown"));
+  }
+
+  @Test
+  public void createSubscriptionShouldUpdateExistingSubscriptionWhenSecretChanges() {
+    UserPushSubscription newSubscription = new UserPushSubscription();
+    newSubscription.setId(SUBSCRIPTION_ID);
+    newSubscription.setEndpoint(SUBSCRIPTION_ENDPOINT);
+    newSubscription.setPushDeviceSecret(PUSH_DEVICE_SECRET);
+
+    when(pwaSubscriptionStorage.get(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
+    when(userPushSubscription.getEndpoint()).thenReturn(SUBSCRIPTION_ENDPOINT);
+    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
+    when(userPushSubscription.getPushDeviceSecret()).thenReturn(null);
+
+    pwaSubscriptionService.createSubscription(newSubscription, TEST_USER);
+
+    verify(pwaSubscriptionStorage).delete(SUBSCRIPTION_ID, TEST_USER);
+    verify(pwaSubscriptionStorage).create(newSubscription, TEST_USER);
+    verify(listenerService, never()).broadcast(PWA_INSTALLED, TEST_USER, newSubscription);
+  }
+
+  @Test
+  public void createSubscriptionShouldUpdateExistingSubscriptionWhenIdChanges() {
+    UserPushSubscription newSubscription = new UserPushSubscription();
+    newSubscription.setId(NEW_SUBSCRIPTION_ID);
+    newSubscription.setEndpoint(SUBSCRIPTION_ENDPOINT);
+    newSubscription.setPushDeviceSecret(PUSH_DEVICE_SECRET);
+
+    when(pwaSubscriptionStorage.get(TEST_USER)).thenReturn(Collections.singletonList(userPushSubscription));
+    when(userPushSubscription.getEndpoint()).thenReturn(SUBSCRIPTION_ENDPOINT);
+    when(userPushSubscription.getId()).thenReturn(SUBSCRIPTION_ID);
+    when(userPushSubscription.getPushDeviceSecret()).thenReturn(PUSH_DEVICE_SECRET);
+
+    pwaSubscriptionService.createSubscription(newSubscription, TEST_USER);
+
+    verify(pwaSubscriptionStorage).delete(SUBSCRIPTION_ID, TEST_USER);
+    verify(pwaSubscriptionStorage).create(newSubscription, TEST_USER);
+  }
+
+  @Test
+  public void deleteSubscriptionShouldNotBroadcastWhenUserActionIsFalse() {
+    when(pwaSubscriptionStorage.delete(SUBSCRIPTION_ID, TEST_USER)).thenReturn(userPushSubscription);
+
+    pwaSubscriptionService.deleteSubscription(SUBSCRIPTION_ID, TEST_USER, false);
+
+    verify(pwaSubscriptionStorage).delete(SUBSCRIPTION_ID, TEST_USER);
+    verifyNoInteractions(listenerService);
   }
 
 }

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaSwServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaSwServiceTest.java
@@ -25,36 +25,34 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.configuration.ConfigurationManager;
 
 @SpringBootTest(classes = {
-                            PwaSwService.class,
+  PwaSwService.class,
 })
 @TestPropertySource(properties = {
-                                   "pwa.service.worker.path=pwa/service-worker.js",
-                    })
+  "pwa.service.worker.path=pwa/service-worker.js",
+})
 public class PwaSwServiceTest {
 
-  @MockBean
+  @MockitoBean
   private PortalContainer      container;
 
-  @MockBean
+  @MockitoBean
   private ConfigurationManager configurationManager;
 
   @Autowired
   private PwaSwService         pwaSwService;
 
   @Test
-  @SuppressWarnings("resource")
   public void getContent() throws Exception {
     assertNull(pwaSwService.getContent());
-
     when(configurationManager.getInputStream("pwa/service-worker.js")).thenAnswer(invocation -> getClass().getClassLoader()
-                                                                                        .getResourceAsStream("pwa/service-worker.js"));
+                                                                                                          .getResourceAsStream("pwa/service-worker.js"));
     assertNotNull(pwaSwService.getContent());
   }
 

--- a/pwa-webapp/src/main/webapp/js/pwa.js
+++ b/pwa-webapp/src/main/webapp/js/pwa.js
@@ -19,6 +19,11 @@
  */
 
 (function(exoi18n) {
+  const pushDeviceDbName = 'pwa-push-device';
+  const pushDeviceStoreName = 'secrets';
+  const pushDeviceSecretKeyPrefix = 'push-device-secret-';
+  const pushVersion = 'v1';
+
   if (!isPwaDisplay()
     && 'onbeforeinstallprompt' in window
     && eXo.env.portal.pwaEnabled
@@ -157,9 +162,13 @@
       });
     }
     if (isNew
-      || subscription.endpoint !== window.localStorage.getItem(`pwa.notification.endpoint-${eXo.env.portal.userName}`)) {
+      || subscription.endpoint !== window.localStorage.getItem(`pwa.notification.endpoint-${eXo.env.portal.userName}`)
+      || !isSamePushVersion()) {
       const key = subscription?.getKey?.('p256dh') || '';
       const auth = subscription?.getKey?.('auth') || '';
+      const subscriptionId = getSubscriptionId();
+      const pushDeviceSecret = await getPushDeviceSecret(subscriptionId);
+      await sendPushDeviceSecretToServiceWorker(registration, subscriptionId, pushDeviceSecret);
       await fetch('/pwa/rest/subscriptions', {
         method: 'POST',
         credentials: 'include',
@@ -167,10 +176,11 @@
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          id: getSubscriptionId(),
+          id: subscriptionId,
           endpoint: subscription.endpoint,
           key: key && btoa(String.fromCharCode.apply(null, new Uint8Array(key))) || '',
-          auth: auth && btoa(String.fromCharCode.apply(null, new Uint8Array(auth))) || ''
+          auth: auth && btoa(String.fromCharCode.apply(null, new Uint8Array(auth))) || '',
+          pushDeviceSecret,
         }),
       })
         .then(() => window.localStorage.setItem(`pwa.notification.endpoint-${eXo.env.portal.userName}`, subscription.endpoint));
@@ -193,7 +203,8 @@
             id: subscriptionId,
           }),
         })
-          .finally(() => {
+          .finally(async () => {
+            await deletePushDeviceSecret(subscriptionId);
             window.localStorage.removeItem(`pwa.notification.subscription.id-${eXo.env.portal.userName}`);
             window.localStorage.removeItem(`pwa.notification.endpoint-${eXo.env.portal.userName}`);
           });
@@ -228,12 +239,89 @@
     return !window.localStorage || window.localStorage.getItem(`pwa.suggested-${eXo.env.portal.userName}`) === 'true';
   }
 
-  function isBatterySettingDisplayed() {
-    return !window.localStorage || window.localStorage.getItem(`pwa.battery-optimization-${eXo.env.portal.userName}`) === 'true';
+  function setPushVersion() {
+    window.localStorage.setItem(`pwa.push-version-${eXo.env.portal.userName}`, pushVersion);
   }
 
-  function setBatterySettingDisplayed() {
-    window.localStorage.setItem(`pwa.battery-optimization-${eXo.env.portal.userName}`, 'true');
+  function isSamePushVersion() {
+    return window.localStorage.getItem(`pwa.push-version-${eXo.env.portal.userName}`) === pushVersion;
+  }
+
+  async function sendPushDeviceSecretToServiceWorker(registration, subscriptionId, pushDeviceSecret) {
+    const serviceWorker = registration?.active || registration?.waiting || registration?.installing || navigator.serviceWorker.controller;
+    serviceWorker?.postMessage?.({
+      action: 'set-push-device-secret',
+      subscriptionId,
+      pushDeviceSecret,
+    });
+  }
+
+  async function getPushDeviceSecret(subscriptionId) {
+    const storageKey = `${pushDeviceSecretKeyPrefix}${subscriptionId}`;
+    let pushDeviceSecret = await getPushDeviceStoreValue(storageKey);
+    if (!pushDeviceSecret) {
+      const secret = new Uint8Array(32);
+      window.crypto.getRandomValues(secret);
+      pushDeviceSecret = btoa(String.fromCharCode.apply(null, secret));
+      await setPushDeviceStoreValue(storageKey, pushDeviceSecret);
+    }
+    return pushDeviceSecret;
+  }
+
+  async function deletePushDeviceSecret(subscriptionId) {
+    return deletePushDeviceStoreValue(`${pushDeviceSecretKeyPrefix}${subscriptionId}`);
+  }
+
+  async function openPushDeviceStore() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(pushDeviceDbName, 1);
+      request.onupgradeneeded = () => request.result.createObjectStore(pushDeviceStoreName);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async function getPushDeviceStoreValue(key) {
+    const db = await openPushDeviceStore();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(pushDeviceStoreName, 'readonly');
+      const request = transaction.objectStore(pushDeviceStoreName).get(key);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+      transaction.oncomplete = () => db.close();
+    });
+  }
+
+  async function setPushDeviceStoreValue(key, value) {
+    const db = await openPushDeviceStore();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(pushDeviceStoreName, 'readwrite');
+      transaction.objectStore(pushDeviceStoreName).put(value, key);
+      transaction.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      transaction.onerror = () => {
+        db.close();
+        reject(transaction.error);
+      };
+    });
+  }
+
+  async function deletePushDeviceStoreValue(key) {
+    const db = await openPushDeviceStore();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(pushDeviceStoreName, 'readwrite');
+      transaction.objectStore(pushDeviceStoreName).delete(key);
+      transaction.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      transaction.onerror = () => {
+        db.close();
+        reject(transaction.error);
+      };
+    });
   }
 
   return {

--- a/pwa-webapp/src/main/webapp/vue-app/user-settings/components/UserSettingPwa.vue
+++ b/pwa-webapp/src/main/webapp/vue-app/user-settings/components/UserSettingPwa.vue
@@ -164,7 +164,6 @@ export default {
     });
     document.addEventListener('pwa-beforeinstallprompt', this.checkInstalled);
     this.pwaSupported = 'onbeforeinstallprompt' in window;
-    console.warn('this.pwaSupported', this.pwaSupported);
     this.checkInstalled();
   },
   mounted() {


### PR DESCRIPTION
This change will allow to access Web Notifications even when the user is disconnected. This will be made by attaching to the Push Notification a dedicated Token which will be used by combining a Device Proof Token stored locally in browser to allow access to the Web Notification even when not connected.