### PR TITLE
feat: Increase Push Notification Delay Detection Alert time - EXO-87655

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -189,7 +189,7 @@ public class PwaNotificationService {
   @Value("${pwa.notifications.push.token.ttl.seconds:28800}") // 8hours
   private int                          pushTokenTtlSeconds;
 
-  @Value("${pwa.notifications.push.token.ttl.excessiveDelayThreshold:30}") // 30sec
+  @Value("${pwa.notifications.push.token.ttl.excessiveDelayThreshold:3600}") // 1 hour
   private int                          pushNotificationExcessiveDelayThreshold;
 
   @Autowired

--- a/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
+++ b/pwa-service/src/test/java/io/meeds/pwa/service/PwaNotificationServiceTest.java
@@ -63,6 +63,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
@@ -89,6 +90,9 @@ import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
 @SpringBootTest(classes = {
   PwaNotificationService.class,
+})
+@TestPropertySource(properties = {
+  "pwa.notifications.push.token.ttl.excessiveDelayThreshold=30",
 })
 public class PwaNotificationServiceTest {
 


### PR DESCRIPTION
Prior to this change, when a push notification isn't received by the user within 30sec, a notification snackbar is displayed informing that the push notification was delayed. This change increases the time to be 1 hour instead.