### PR TITLE
fix: Update the existing Web Notification parameters without marking it as read - EXO-87664

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -274,11 +274,10 @@ public class PwaNotificationService {
     ownerParameters.put(PWA_NOTIFICATION_PUSH_RECEIVED_TIME, String.valueOf(receivedAt));
     ownerParameters.put(PWA_NOTIFICATION_PUSH_EFFECTIVE_RECEIVED_TIME, String.valueOf(System.currentTimeMillis()));
     ownerParameters.put(PWA_NOTIFICATION_PUSH_DELAY_TIME, String.valueOf(System.currentTimeMillis() - sentAt));
-    notification.setOwnerParameter(ownerParameters);
-
-    webNotificationService.update(notification, false);
+    webNotificationService.updateNotificationParameters(notification.getId(), ownerParameters);
 
     UserPushSubscription subscription = pwaSubscriptionService.getSubscription(username, subscriptionId);
+    notification.setOwnerParameter(ownerParameters);
     listenerService.broadcast(PWA_NOTIFICATION_RECEIVED,
                               subscription,
                               notification);


### PR DESCRIPTION
Prior to this change, when updating a Web notification to add delivery information, it marks it as read. This change will use the newly introduced API method which updates the parameters without marking the notification as Read.