### PR TITLE
feat: Use PWA portrait Orientation rather than any - EXO-87665

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/rest/ServiceWorkerRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/ServiceWorkerRest.java
@@ -61,7 +61,7 @@ public class ServiceWorkerRest {
       } else {
         return ResponseEntity.ok()
                              .eTag(String.valueOf(content.hashCode()))
-                             .header("Service-Worker-Allowed", "/")
+                             .headers(h -> h.set("Service-Worker-Allowed", "/"))
                              .contentType(MediaType.valueOf("text/javascript"))
                              .cacheControl(CacheControl.noCache())
                              .body(content);

--- a/pwa-service/src/main/java/io/meeds/pwa/web/ServiceWorkerRootWebAppFilter.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/web/ServiceWorkerRootWebAppFilter.java
@@ -50,9 +50,6 @@ public class ServiceWorkerRootWebAppFilter implements RootWebappFilterPlugin {
   public void doFilter(HttpServletRequest httpRequest,
                        HttpServletResponse httpResponse,
                        FilterChain chain) throws IOException, ServletException {
-    httpResponse.setHeader("Service-Worker-Allowed", "/");
-    httpResponse.setHeader("Cache-Control", "no-cache");
-    httpResponse.setHeader("Content-Type", "text/javascript");
     PortalContainer.getInstance()
                    .getServletContexts()
                    .stream()

--- a/pwa-service/src/main/resources/pwa/manifest.json
+++ b/pwa-service/src/main/resources/pwa/manifest.json
@@ -50,7 +50,7 @@
   "handle_links": "preferred",
   "screenshots": [],
   "categories": ["business", "productivity", "social", "utilities"],
-  "orientation": "any",
+  "orientation": "portrait",
   "related_applications": [{
     "platform": "webapp",
     "url": "$fullDomainUrl/pwa/rest/manifest"


### PR DESCRIPTION
Prior to this change, the PWA orientation is set to any which makes it doesn't use the preferred orientation of Device. This change will set it as protrait in order to allow to set a preferred orientation.