### PR TITLE
fix: Give Access to PWA Help Drawer all time - EXO-87679

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/web/ServiceWorkerRootWebAppFilter.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/web/ServiceWorkerRootWebAppFilter.java
@@ -50,9 +50,6 @@ public class ServiceWorkerRootWebAppFilter implements RootWebappFilterPlugin {
   public void doFilter(HttpServletRequest httpRequest,
                        HttpServletResponse httpResponse,
                        FilterChain chain) throws IOException, ServletException {
-    httpResponse.setHeader("Service-Worker-Allowed", "/");
-    httpResponse.setHeader("Cache-Control", "no-cache");
-    httpResponse.setHeader("Content-Type", "text/javascript");
     PortalContainer.getInstance()
                    .getServletContexts()
                    .stream()

--- a/pwa-webapp/src/main/webapp/vue-app/user-settings/components/UserSettingPwa.vue
+++ b/pwa-webapp/src/main/webapp/vue-app/user-settings/components/UserSettingPwa.vue
@@ -38,7 +38,6 @@
                   <v-btn
                     :aria-label="$t('UserSettings.pwa.install')"
                     :loading="loading"
-                    :disabled="disabledButton || !pwaEnabled"
                     class="btn"
                     @click.native="installPwa">
                     {{ $t('UserSettings.pwa.install') }}
@@ -162,7 +161,6 @@ export default {
     pwaEnabled: eXo.env.portal.pwaEnabled,
     pwaSupported: true,
     notificationPermission: Notification.permission,
-    disabledButton: false,
     isIOs: false,
     loading: false,
     permissionLoading: false,
@@ -229,7 +227,7 @@ export default {
       }
     },
     async installPwa() {
-      if (this.pwaSupported) {
+      if (this.pwaSupported && window.deferredPwaPrompt) {
         this.loading = true;
         try {
           await window.deferredPwaPrompt.prompt();


### PR DESCRIPTION
Prior to this change, sometimes the access to the Help Drawer is disabled. This change ensures to have all time access to the Help Drawer independently from PWA support inside the Browser.