### PR TITLE
feat: Use PWA default Orientation rather than any - EXO-87665

### DIFF
--- a/pwa-service/src/main/resources/pwa/manifest.json
+++ b/pwa-service/src/main/resources/pwa/manifest.json
@@ -50,7 +50,6 @@
   "handle_links": "preferred",
   "screenshots": [],
   "categories": ["business", "productivity", "social", "utilities"],
-  "orientation": "any",
   "related_applications": [{
     "platform": "webapp",
     "url": "$fullDomainUrl/pwa/rest/manifest"


### PR DESCRIPTION
Prior to this change, the PWA orientation is set to any which makes it doesn't use the preferred orientation of Device. This change will set it as null in order to allow to set a preferred orientation from Device settings.