### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/pwa-plugin/src/main/java/io/meeds/pwa/plugin/analytics/BasePwaStatisticCollector.java
+++ b/pwa-plugin/src/main/java/io/meeds/pwa/plugin/analytics/BasePwaStatisticCollector.java
@@ -34,9 +34,9 @@ public abstract class BasePwaStatisticCollector {
     StatisticData statisticData = new StatisticData();
     statisticData.setModule("PWA");
     statisticData.setUserId(Long.parseLong(getIdentityId(username)));
-    statisticData.addParameter("pwaDeviceType", subscription.getDeviceType());
-    statisticData.addParameter("pwaSubscriptionId", subscription.getId());
-    statisticData.addParameter("pwaSubscriptionSite", getSubscriptionDomain(subscription.getEndpoint()));
+    statisticData.addKeyword("pwaDeviceType", subscription.getDeviceType());
+    statisticData.addKeyword("pwaSubscriptionId", subscription.getId());
+    statisticData.addKeyword("pwaSubscriptionSite", getSubscriptionDomain(subscription.getEndpoint()));
     return statisticData;
   }
 

--- a/pwa-plugin/src/main/java/io/meeds/pwa/plugin/analytics/PwaNotificationListener.java
+++ b/pwa-plugin/src/main/java/io/meeds/pwa/plugin/analytics/PwaNotificationListener.java
@@ -98,19 +98,19 @@ public class PwaNotificationListener extends BasePwaStatisticCollector implement
 
   private void addHttpResponseCode(StatisticData statisticData, HttpResponse httpResponse) {
     if (httpResponse != null && httpResponse.getStatusLine() != null) {
-      statisticData.addParameter("pwaHttpResponseCode", httpResponse.getStatusLine().getStatusCode());
+      statisticData.addLong("pwaHttpResponseCode", httpResponse.getStatusLine().getStatusCode());
     }
   }
 
   private void addNotificationId(StatisticData statisticData, Long notificationId) {
     if (notificationId != null) {
-      statisticData.addParameter("pwaNotificationId", notificationId);
+      statisticData.addKeyword("pwaNotificationId", notificationId);
     }
   }
 
   private void addNotificationAction(StatisticData statisticData, String action) {
     if (StringUtils.isNotBlank(action)) {
-      statisticData.addParameter("pwaAction", action);
+      statisticData.addKeyword("pwaAction", action);
     }
   }
 
@@ -119,7 +119,7 @@ public class PwaNotificationListener extends BasePwaStatisticCollector implement
       errorMessage = getErrorMessage(httpResponse);
     }
     if (StringUtils.isNotBlank(errorMessage)) {
-      statisticData.addParameter("pwaErrorMessage", errorMessage);
+      statisticData.addKeyword("pwaErrorMessage", errorMessage);
     }
   }
 

--- a/pwa-plugin/src/main/java/io/meeds/pwa/plugin/analytics/PwaNotificationReceivedListener.java
+++ b/pwa-plugin/src/main/java/io/meeds/pwa/plugin/analytics/PwaNotificationReceivedListener.java
@@ -69,14 +69,14 @@ public class PwaNotificationReceivedListener extends BasePwaStatisticCollector
     statisticData.setStatus(StatisticStatus.OK);
     statisticData.setDuration(Long.parseLong(notificationInfo.getOwnerParameter().get(PWA_NOTIFICATION_PUSH_DELAY_TIME)));
 
-    statisticData.addParameter("pwaNotificationId", Long.parseLong(notificationInfo.getId()));
-    statisticData.addParameter("pwaNotificationSentAt",
-                               Long.parseLong(notificationInfo.getOwnerParameter().get(PWA_NOTIFICATION_PUSH_SENT_TIME)));
-    statisticData.addParameter("pwaNotificationClientReceivedAt",
-                               Long.parseLong(notificationInfo.getOwnerParameter().get(PWA_NOTIFICATION_PUSH_RECEIVED_TIME)));
-    statisticData.addParameter("pwaNotificationServerReceivedAt",
-                               Long.parseLong(notificationInfo.getOwnerParameter()
-                                                              .get(PWA_NOTIFICATION_PUSH_EFFECTIVE_RECEIVED_TIME)));
+    statisticData.addKeyword("pwaNotificationId", Long.parseLong(notificationInfo.getId()));
+    statisticData.addLong("pwaNotificationSentAt",
+                          notificationInfo.getOwnerParameter().get(PWA_NOTIFICATION_PUSH_SENT_TIME));
+    statisticData.addLong("pwaNotificationClientReceivedAt",
+                          notificationInfo.getOwnerParameter().get(PWA_NOTIFICATION_PUSH_RECEIVED_TIME));
+    statisticData.addLong("pwaNotificationServerReceivedAt",
+                          notificationInfo.getOwnerParameter()
+                                                         .get(PWA_NOTIFICATION_PUSH_EFFECTIVE_RECEIVED_TIME));
     addStatisticData(statisticData);
   }
 


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.