### PR TITLE
feat: compute app badge from pluggable unread counters - EXO-87789

### DIFF
--- a/pwa-service/src/main/java/io/meeds/pwa/plugin/PwaBadgePlugin.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/plugin/PwaBadgePlugin.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.pwa.plugin;
+
+public interface PwaBadgePlugin {
+
+  String getId();
+
+  default boolean isEnabled(String username) {
+    return true;
+  }
+
+  int getBadge(String username);
+
+}

--- a/pwa-service/src/main/java/io/meeds/pwa/plugin/WebNotificationPwaBadgePlugin.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/plugin/WebNotificationPwaBadgePlugin.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.pwa.plugin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.commons.api.notification.model.UserSetting;
+import org.exoplatform.commons.api.notification.service.WebNotificationService;
+import org.exoplatform.commons.api.notification.service.setting.UserSettingService;
+import org.exoplatform.commons.notification.channel.WebChannel;
+
+@Component
+public class WebNotificationPwaBadgePlugin implements PwaBadgePlugin {
+
+  public static final String     ID = WebChannel.ID;
+
+  @Autowired
+  private WebNotificationService webNotificationService;
+
+  @Autowired
+  private UserSettingService     userSettingService;
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public boolean isEnabled(String username) {
+    UserSetting userSetting = userSettingService.get(username);
+    return userSetting != null
+           && userSetting.isEnabled()
+           && userSetting.isChannelGloballyActive(WebChannel.ID);
+  }
+
+  @Override
+  public int getBadge(String username) {
+    return webNotificationService.getNumberOnBadge(username);
+  }
+
+}

--- a/pwa-service/src/main/java/io/meeds/pwa/rest/PwaNotificationRest.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/rest/PwaNotificationRest.java
@@ -171,6 +171,16 @@ public class PwaNotificationRest {
     pwaNotificationService.resetPushDeliveryDelay(request.getRemoteUser(), subscriptionId);
   }
 
+  @GetMapping("badge")
+  @Secured("users")
+  @Operation(summary = "Get PWA badge count", description = "Get the current PWA application badge count", method = "GET")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "PWA badge count retrieved"),
+  })
+  public Map<String, Object> getBadge(HttpServletRequest request) {
+    return pwaNotificationService.getBadge(request.getRemoteUser());
+  }
+
   @PatchMapping(path = "{id}", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   @Secured("users")
   @Operation(summary = "Update Web Notification specific property", description = "Update Web Notification specific property", method = "PATCH")

--- a/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
+++ b/pwa-service/src/main/java/io/meeds/pwa/service/PwaNotificationService.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ import io.meeds.pwa.model.PwaNotificationAction;
 import io.meeds.pwa.model.PwaNotificationMessage;
 import io.meeds.pwa.model.UserPushSubscription;
 import io.meeds.pwa.plugin.DefaultPwaNotificationPlugin;
+import io.meeds.pwa.plugin.PwaBadgePlugin;
 import io.meeds.pwa.plugin.PwaNotificationPlugin;
 import io.meeds.pwa.storage.PwaNotificationStorage;
 
@@ -189,11 +191,15 @@ public class PwaNotificationService {
   @Value("${pwa.notifications.push.token.ttl.seconds:28800}") // 8hours
   private int                          pushTokenTtlSeconds;
 
-  @Value("${pwa.notifications.push.token.ttl.excessiveDelayThreshold:3600}") // 1 hour
+  // 1 hour
+  @Value("${pwa.notifications.push.token.ttl.excessiveDelayThreshold:3600}")
   private int                          pushNotificationExcessiveDelayThreshold;
 
   @Autowired
   private List<PwaNotificationPlugin>  plugins;
+
+  @Autowired(required = false)
+  private List<PwaBadgePlugin>         badgePlugins                                  = Collections.emptyList();
 
   private ScheduledExecutorService     executorService;
 
@@ -231,7 +237,7 @@ public class PwaNotificationService {
   public PwaNotificationMessage getNotificationFromPush(long webNotificationId,
                                                         String authorizationHeader,
                                                         String username) throws ObjectNotFoundException,
-                                                                                    IllegalAccessException {
+                                                                         IllegalAccessException {
     if (StringUtils.isBlank(username)) {
       username = validatePushNotificationAccess(webNotificationId, authorizationHeader, true);
     }
@@ -242,7 +248,7 @@ public class PwaNotificationService {
                                          String action,
                                          String authorizationHeader,
                                          String username) throws ObjectNotFoundException,
-                                                                     IllegalAccessException {
+                                                          IllegalAccessException {
     if (StringUtils.isBlank(username)) {
       username = validatePushNotificationAccess(webNotificationId, authorizationHeader, true);
     }
@@ -264,7 +270,10 @@ public class PwaNotificationService {
     } else if (!StringUtils.equals(notification.getTo(), username)) {
       throw new IllegalAccessException(String.format(MSG_NOTIFICATION_ACCESS_DENIED, webNotificationId));
     }
-    long computedDelayMs = System.currentTimeMillis() - sentAt; // Both generated in server side, thus it's compatible rather than using the Client time in MS
+    // @formatter:off
+    // Both generated in server side, thus it's compatible rather than using the Client time in MS
+    long computedDelayMs = System.currentTimeMillis() - sentAt;
+    // @formatter:on
     if ((computedDelayMs / 1000) > pushNotificationExcessiveDelayThreshold) {
       pwaNotificationStorage.recordExcessivePushDeliveryDelay(username, subscriptionId, Math.max(0, computedDelayMs));
     }
@@ -289,6 +298,29 @@ public class PwaNotificationService {
 
   public void resetPushDeliveryDelay(String username, String subscriptionId) {
     pwaNotificationStorage.resetPushDeliveryDelay(username, subscriptionId);
+  }
+
+  public Map<String, Object> getBadge(String username) {
+    Map<String, Integer> badges = new HashMap<>();
+    int total = 0;
+    for (PwaBadgePlugin badgePlugin : badgePlugins) {
+      try {
+        if (badgePlugin.isEnabled(username)) {
+          int count = Math.max(0, badgePlugin.getBadge(username));
+          badges.put(badgePlugin.getId(), count);
+          total += count;
+        }
+      } catch (Exception e) {
+        log.warn("Error computing PWA badge for plugin {} and user {}. Continue computing other type of badges.",
+                 badgePlugin.getId(),
+                 username,
+                 e);
+      }
+    }
+    Map<String, Object> badge = new HashMap<>();
+    badge.put("badges", badges);
+    badge.put("total", total);
+    return badge;
   }
 
   public void updateNotification(long webNotificationId, String action, String username) throws ObjectNotFoundException,

--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -43,6 +43,7 @@ const pushDeviceDbName = 'pwa-push-device';
 const pushDeviceStoreName = 'secrets';
 const pushDeviceSecretKeyPrefix = 'push-device-secret-';
 const pushAuthScheme = 'PWA-Notification';
+const badgeUrl = '/pwa/rest/notifications/badge';
 
 const checkCache = async () => {
   const version = await getCacheVersion();
@@ -167,6 +168,10 @@ self.addEventListener('message', event => {
       && event.data.subscriptionId
       && event.data.pushDeviceSecret) {
     event.waitUntil(setPushDeviceSecret(event.data.subscriptionId, event.data.pushDeviceSecret));
+  } else if (event?.data?.action === 'refresh-badge') {
+    event.waitUntil(refreshBadge());
+  } else if (event?.data?.action === 'set-badge-count') {
+    event.waitUntil(updateAppBadge(event.data.count));
   }
 });
 
@@ -261,7 +266,7 @@ self.addEventListener('notificationclick', event => {
 });
 
 self.addEventListener('notificationclose', event => {
-  event.waitUntil(refreshBadge);
+  event.waitUntil(refreshBadge());
 });
 
 async function markAsRead(notificationId, notificationAccessToken, subscriptionId) {
@@ -430,13 +435,33 @@ async function setPushDeviceStoreValue(key, value) {
 }
 
 async function refreshBadge() {
-  if (navigator.setAppBadge) {
-    const notifications = await self.registration.getNotifications();
-    if (notifications?.length) {
-      await navigator?.setAppBadge?.(notifications.length);
-    } else {
-      await navigator?.clearAppBadge?.();
+  if (!navigator.setAppBadge) {
+    return;
+  }
+  try {
+    const response = await fetch(badgeUrl, {
+      method: 'GET',
+      credentials: 'include',
+      cache: 'no-store',
+    });
+    if (response.ok) {
+      const badge = await response.json();
+      await updateAppBadge(badge?.total ?? badge?.count ?? 0);
     }
+  } catch (e) {
+    console.error('Error refreshing app badge', e);
+  }
+}
+
+async function updateAppBadge(count) {
+  if (!navigator.setAppBadge) {
+    return;
+  }
+  const badgeCount = Number(count || 0);
+  if (badgeCount > 0) {
+    await navigator.setAppBadge(badgeCount);
+  } else {
+    await navigator.clearAppBadge();
   }
 }
 

--- a/pwa-webapp/src/main/webapp/js/pwa.js
+++ b/pwa-webapp/src/main/webapp/js/pwa.js
@@ -23,6 +23,8 @@
   const pushDeviceStoreName = 'secrets';
   const pushDeviceSecretKeyPrefix = 'push-device-secret-';
   const pushVersion = 'v1.0';
+  const minBadgeRefreshInterval = 60000;
+  let lastBadgeRefreshTime = 0;
 
   if (!isPwaDisplay()
     && 'onbeforeinstallprompt' in window
@@ -72,6 +74,7 @@
   });
 
   async function init() {
+    initBadgeRefreshListeners();
     if (isPwaDisplay()
       && eXo?.env?.portal?.userName
       && eXo?.env?.portal?.pwaEnabled
@@ -125,6 +128,37 @@
       });
     } catch (e) {
       console.error('Error resetting push delivery delay status', e);
+    }
+  }
+
+  function initBadgeRefreshListeners() {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        refreshAppBadgeIfStale();
+      }
+    });
+    window.addEventListener('focus', refreshAppBadgeIfStale);
+    document.addEventListener('cometdNotifEvent', event => refreshAppBadge(event?.detail?.data?.numberOnBadge));
+    document.addEventListener('pwa-refresh-badge', event => refreshAppBadge(event?.detail?.count));
+  }
+
+  function refreshAppBadgeIfStale() {
+    if (Date.now() - lastBadgeRefreshTime >= minBadgeRefreshInterval) {
+      refreshAppBadge();
+    }
+  }
+
+  async function refreshAppBadge(count) {
+    try {
+      const registration = await navigator.serviceWorker?.ready;
+      const serviceWorker = registration?.active || navigator.serviceWorker?.controller;
+      serviceWorker?.postMessage?.({
+        action: Number.isFinite(Number(count)) ? 'set-badge-count' : 'refresh-badge',
+        count,
+      });
+      lastBadgeRefreshTime = Date.now();
+    } catch (e) {
+      console.error('Error refreshing app badge', e);
     }
   }
 
@@ -411,5 +445,6 @@
     getSubscriptionId,
     getPushDeliveryDelayStatus,
     resetPushDeliveryDelayStatus,
+    refreshAppBadge,
   };
 })(exoi18n);


### PR DESCRIPTION
Replace the PWA badge count based on displayed push notifications with a server-side unread badge endpoint.

Add a PwaBadgePlugin SPI so addons can contribute their own badge counters without introducing dependencies from PWA to those addons. Add the default Web notification badge plugin using the Web channel settings.

Refresh the app badge from CometD notification events and throttled app resume events, while keeping push notifications only for user-visible notifications.