### PR TITLE
feat: Avoid loading Desktop Notif URL in non-portal tab - EXO-87813

### DIFF
--- a/pwa-service/src/main/resources/pwa/service-worker.js
+++ b/pwa-service/src/main/resources/pwa/service-worker.js
@@ -231,7 +231,8 @@ self.addEventListener('notificationclick', event => {
         let matchingClient = null;
         let i = 0;
         while (!matchingClient && i < windowClients.length) {
-          if (!windowClients[i].url.replace(self.location.origin, '').includes('editor')) {
+          const url = windowClients[i].url.replace(self.location.origin, '');
+          if (!url.includes('editor') && url.startsWith('/portal')) {
             matchingClient = windowClients[i];
           } else {
             i++;


### PR DESCRIPTION
Prior to this change, any URL other than 'editor's can be used by Desktop Notif URL to display in current page the page to load. This change ensures to avoid loading the Desktop Notif Page URL in a non portal pages like Web Conf standalone page.